### PR TITLE
Use local `ronin` package

### DIFF
--- a/src/commands/migration.ts
+++ b/src/commands/migration.ts
@@ -209,7 +209,12 @@ const apply = async (
 
   try {
     const { slug } = await getOrSelectSpaceId(sessionToken, spinner);
-    const existingModels = await getModels(db, appToken, slug, flags.prod);
+    const existingModels = await getModels(
+      db,
+      appToken ?? sessionToken,
+      slug,
+      flags.prod,
+    );
     const protocol = await new Protocol().load(migrationFilePath);
     const statements = protocol.getSQLStatements(existingModels);
 

--- a/src/commands/migration.ts
+++ b/src/commands/migration.ts
@@ -235,6 +235,7 @@ const apply = async (
     spinner.succeed('Successfully applied migration');
     process.exit(0);
   } catch (error) {
+    console.log(error);
     spinner.fail('Failed to apply migration');
     throw error;
   }

--- a/src/commands/migration.ts
+++ b/src/commands/migration.ts
@@ -240,7 +240,6 @@ const apply = async (
     spinner.succeed('Successfully applied migration');
     process.exit(0);
   } catch (error) {
-    console.log(error);
     spinner.fail('Failed to apply migration');
     throw error;
   }

--- a/src/utils/protocol.ts
+++ b/src/utils/protocol.ts
@@ -3,10 +3,9 @@ import path from 'node:path';
 import { formatCode } from '@/src/utils/format';
 import { type Model, type Query, type Statement, Transaction } from '@ronin/compiler';
 
-const ronin = await import(path.join(process.cwd(), 'node_modules', 'ronin'));
-const roninUtils = await import(
-  path.join(process.cwd(), 'node_modules', 'ronin/dist/utils')
-);
+const localRoninPath = path.join(process.cwd(), 'node_modules', 'ronin');
+const ronin = await import(localRoninPath);
+const roninUtils = await import(path.join(localRoninPath, 'dist/utils'));
 
 const { add, alter, create, drop, get, set } = ronin;
 const { getBatchProxy } = roninUtils;

--- a/src/utils/protocol.ts
+++ b/src/utils/protocol.ts
@@ -4,11 +4,12 @@ import { formatCode } from '@/src/utils/format';
 import { type Model, type Query, type Statement, Transaction } from '@ronin/compiler';
 
 const ronin = await import(path.join(process.cwd(), 'node_modules', 'ronin'));
-const roninUtils = await import(path.join(process.cwd(), 'node_modules', 'ronin/dist/utils'));
+const roninUtils = await import(
+  path.join(process.cwd(), 'node_modules', 'ronin/dist/utils')
+);
 
 const { add, alter, create, drop, get, set } = ronin;
 const { getBatchProxy } = roninUtils;
-
 
 /**
  * Protocol represents a set of database migration queries that can be executed in sequence.

--- a/src/utils/protocol.ts
+++ b/src/utils/protocol.ts
@@ -2,8 +2,13 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { formatCode } from '@/src/utils/format';
 import { type Model, type Query, type Statement, Transaction } from '@ronin/compiler';
-import { add, alter, create, drop, get, set } from 'ronin';
-import { getBatchProxy } from 'ronin/utils';
+
+const ronin = await import(path.join(process.cwd(), 'node_modules', 'ronin'));
+const roninUtils = await import(path.join(process.cwd(), 'node_modules', 'ronin/dist/utils'));
+
+const { add, alter, create, drop, get, set } = ronin;
+const { getBatchProxy } = roninUtils;
+
 
 /**
  * Protocol represents a set of database migration queries that can be executed in sequence.
@@ -45,7 +50,7 @@ export class Protocol {
     const queryObjects = await getBatchProxy(
       () => queries.map((query) => this.queryToObject(query).query),
       { asyncContext: new (await import('node:async_hooks')).AsyncLocalStorage() },
-      (queries) => queries,
+      (queries: Array<Query>) => queries,
     );
     return queryObjects;
   };
@@ -118,14 +123,13 @@ export default () => [
     if (!fs.existsSync(filePath)) {
       throw new Error(`Migration protocol file ${filePath} does not exist`);
     }
-
     const queries = await import(filePath);
     const queryObjects = getBatchProxy(
       () => {
         return queries.default();
       },
       { asyncContext: new (await import('node:async_hooks')).AsyncLocalStorage() },
-      async (r) => r,
+      async (r: Array<Query>) => r,
     );
 
     this._queries = (await queryObjects).map((query: { query: Query }) => query.query);


### PR DESCRIPTION
To ensure the `getBatchProxy` function operates correctly, it was necessary for the global and local versions of ronin to be synchronized. To address the issue of version mismatch, we have updated the implementation to dynamically import `ronin` from the project's local `node_modules` directory, rather than relying on the globally installed version.