### PR TITLE
Automatically create migration directory

### DIFF
--- a/src/commands/migration.ts
+++ b/src/commands/migration.ts
@@ -164,7 +164,10 @@ const create = async (
     if (flags.apply) {
       const statements = protocol.getSQLStatements(existingModels);
       const migrationsPath = path.join(process.cwd(), MODELS_IN_CODE_DIR, 'migrations');
-      fs.mkdirSync(migrationsPath, { recursive: true });
+
+      if (!fs.existsSync(migrationsPath)) {
+        fs.mkdirSync(migrationsPath, { recursive: true });
+      }
 
       fs.copyFileSync(
         path.join(
@@ -224,6 +227,11 @@ const apply = async (
     const latestProtocolFile = files.sort().pop() || 'migration';
 
     const migrationsPath = path.join(process.cwd(), MODELS_IN_CODE_DIR, 'migrations');
+
+    if (!fs.existsSync(migrationsPath)) {
+      fs.mkdirSync(migrationsPath, { recursive: true });
+    }
+
     fs.copyFileSync(
       migrationFilePath ||
         path.join(

--- a/src/commands/migration.ts
+++ b/src/commands/migration.ts
@@ -75,7 +75,7 @@ const applyMigrationStatements = async (
   slug: string,
 ): Promise<void> => {
   if (flags.prod) {
-    console.log('Applying migration to production database');
+    console.log('\nApplying migration to production database');
 
     await fetch(`https://data.ronin.co/?data-selector=${slug}`, {
       method: 'POST',
@@ -94,7 +94,7 @@ const applyMigrationStatements = async (
     return;
   }
 
-  console.log('Applying migration to local database');
+  console.log('\nApplying migration to local database');
 
   await db.query(statements.map(({ statement }) => statement));
   fs.writeFileSync('.ronin/db.sqlite', await db.getContents());


### PR DESCRIPTION
Automatically create the migration directory when the `apply` command is executed and the directory is missing.