### PR TITLE
Restrict field renaming to one occurrence

### DIFF
--- a/src/utils/field.ts
+++ b/src/utils/field.ts
@@ -95,7 +95,7 @@ export const fieldsToRename = (
   existingFields: Array<ModelField>,
 ): Array<{ from: ModelField; to: ModelField }> => {
   const fieldsToCreated = fieldsToCreate(definedFields, existingFields);
-  const fieldsToDropped = fieldsToDrop(definedFields, existingFields);
+  let fieldsToDropped = fieldsToDrop(definedFields, existingFields);
 
   const fieldsToRename: Array<{ from: ModelField; to: ModelField }> = [];
 
@@ -116,6 +116,7 @@ export const fieldsToRename = (
 
     if (currentField) {
       fieldsToRename.push({ from: currentField, to: field });
+      fieldsToDropped = fieldsToDropped.filter((s) => s.slug !== currentField.slug);
     }
   }
 

--- a/tests/fixtures/index.ts
+++ b/tests/fixtures/index.ts
@@ -228,3 +228,22 @@ export const TestG = model({
     name: string(),
   },
 }) as unknown as Model;
+
+export const TestH = model({
+  slug: 'test',
+  fields: {
+    age: string(),
+    name: string(),
+    description: string(),
+  },
+}) as unknown as Model;
+
+export const TestI = model({
+  slug: 'test',
+  fields: {
+    age: string(),
+    name: string(),
+    bio: string(),
+    colour: string(),
+  },
+}) as unknown as Model;

--- a/tests/utils/apply.test.ts
+++ b/tests/utils/apply.test.ts
@@ -9,6 +9,8 @@ import {
   TestE,
   TestF,
   TestG,
+  TestH,
+  TestI,
 } from '@/fixtures/index';
 
 import { describe, expect, test } from 'bun:test';
@@ -354,5 +356,24 @@ describe('apply', () => {
 
     const newModels = await getModels(db);
     expect(newModels.length).toBe(allModels.length);
+  });
+
+  test('create model with field rename', async () => {
+    const definedModels: Array<Model> = [TestI];
+    const existingModels: Array<Model> = [TestH];
+
+    const db = await queryEphemeralDatabase(existingModels);
+    const models = await getModels(db);
+
+    const modelDiff = await diffModels(definedModels, models, true);
+
+    const protocol = new Protocol(modelDiff);
+    await protocol.convertToQueryObjects();
+
+    const statements = protocol.getSQLStatements(models);
+    await db.query(statements);
+
+    const newModels = await getModels(db);
+    expect(newModels).toHaveLength(1);
   });
 });


### PR DESCRIPTION
A customer on Discord highlighted an issue where the CLI suggested renaming a field from `A` to `B` and `A` to `C` within the same migration creation process, which is illogical. This PR addresses the issue by ensuring that a field can only be renamed once per migration creation step.