### PR TITLE
Use prod DB as basis for migrations

### DIFF
--- a/tests/utils/model.test.ts
+++ b/tests/utils/model.test.ts
@@ -56,7 +56,7 @@ describe('models', () => {
         method: 'POST',
       });
 
-      const models = await getModels(db, '', 'updated-bsql-ip', true);
+      const models = await getModels(db, '', 'updated-bsql-ip', false);
 
       expect(models).toStrictEqual([]);
       expect(models).toHaveLength(0);
@@ -77,7 +77,7 @@ describe('models', () => {
         method: 'POST',
       });
 
-      const models = await getModels(db, '', 'updated-bsql-ip', true);
+      const models = await getModels(db, '', 'updated-bsql-ip', false);
 
       expect(models).toStrictEqual([]);
       expect(models).toHaveLength(0);
@@ -92,7 +92,7 @@ describe('models', () => {
       });
 
       try {
-        await getModels(db, '', '', true);
+        await getModels(db, '', '', false);
       } catch (err) {
         const error = err as Error;
         expect(error).toBeInstanceOf(Error);


### PR DESCRIPTION
By default, in order to maximize efficiency, migrations should be created from the current state of the production database, not from the state of a local database, as that is the most common use case, even for larger apps.

When it comes to applying, however, migrations should ideally first be applied to a local database and tested there, which is something we will likely start defaulting to very soon, once it's possible to easily hook up a local DB to your app.