### PR TITLE
Resolved unnecessary table recreation in migrations

### DIFF
--- a/src/utils/field.ts
+++ b/src/utils/field.ts
@@ -277,7 +277,7 @@ const deleteFields = (fields: Array<ModelField>, modelSlug: string): Array<strin
 export const fieldsAreDifferent = (local: ModelField, remote: ModelField): boolean => {
   return (
     local.type !== remote.type ||
-    local.name !== remote.name ||
+    (local.name && local.name !== remote.name) ||
     local.slug !== remote.slug ||
     local.unique !== remote.unique ||
     local.required !== remote.required ||

--- a/src/utils/migration.ts
+++ b/src/utils/migration.ts
@@ -308,7 +308,7 @@ export const createTriggers = (
   const definedTriggers = definedModel.triggers || [];
   const existingTriggers = existingModel.triggers || [];
 
-  // Find every trigger that is defined but not in existing
+  // Find every trigger that is defined but not in `existingModel`
   const triggersToAdd = definedTriggers.filter(
     (i) =>
       !existingTriggers.some(

--- a/src/utils/migration.ts
+++ b/src/utils/migration.ts
@@ -249,7 +249,6 @@ export const triggersToRecreate = (
   definedModels: Array<Model>,
   existingModels: Array<Model>,
 ): Array<string> => {
-
   const diff: Array<string> = [];
 
   for (const definedModel of definedModels) {
@@ -271,7 +270,10 @@ export const triggersToRecreate = (
   return diff;
 };
 
-export const dropTriggers = (definedModel: Model, existingModel: Model): Array<string> => {
+export const dropTriggers = (
+  definedModel: Model,
+  existingModel: Model,
+): Array<string> => {
   const diff: Array<string> = [];
   const definedTriggers = definedModel.triggers || [];
   const existingTriggers = existingModel.triggers || [];
@@ -298,7 +300,10 @@ export const dropTriggers = (definedModel: Model, existingModel: Model): Array<s
   return diff;
 };
 
-export const createTriggers = (definedModel: Model, existingModel: Model): Array<string> => {
+export const createTriggers = (
+  definedModel: Model,
+  existingModel: Model,
+): Array<string> => {
   const diff: Array<string> = [];
   const definedTriggers = definedModel.triggers || [];
   const existingTriggers = existingModel.triggers || [];

--- a/tests/fixtures/utils.ts
+++ b/tests/fixtures/utils.ts
@@ -1,3 +1,4 @@
+import { createTriggerQuery } from '@/src/utils/queries';
 import { ROOT_MODEL, Transaction } from '@ronin/compiler';
 
 import type { Model } from '@ronin/compiler';
@@ -37,8 +38,12 @@ export const prefillDatabase = async (
 ): Promise<void> => {
   const rootModelTransaction = new Transaction([{ create: { model: ROOT_MODEL } }]);
 
+  const triggers = models.flatMap((model) => model.triggers?.flatMap((trigger) => ({alter: { model: model.slug, create: { trigger } }})) ?? []);
+
   const modelTransaction = new Transaction(
-    models.map((model) => ({ create: { model } })),
+    // @ts-expect-error This is a temporay fix and will be removed as soon as create.model
+    // supports triggers.
+    models.map((model) => ({ create: { model } })).concat(triggers),
   );
 
   await db.query([...rootModelTransaction.statements, ...modelTransaction.statements]);

--- a/tests/fixtures/utils.ts
+++ b/tests/fixtures/utils.ts
@@ -1,4 +1,3 @@
-import { createTriggerQuery } from '@/src/utils/queries';
 import { ROOT_MODEL, Transaction } from '@ronin/compiler';
 
 import type { Model } from '@ronin/compiler';
@@ -38,12 +37,19 @@ export const prefillDatabase = async (
 ): Promise<void> => {
   const rootModelTransaction = new Transaction([{ create: { model: ROOT_MODEL } }]);
 
-  const triggers = models.flatMap((model) => model.triggers?.flatMap((trigger) => ({alter: { model: model.slug, create: { trigger } }})) ?? []);
+  const triggers = models.flatMap(
+    (model) =>
+      model.triggers?.flatMap((trigger) => ({
+        alter: { model: model.slug, create: { trigger } },
+      })) ?? [],
+  );
 
   const modelTransaction = new Transaction(
     // @ts-expect-error This is a temporay fix and will be removed as soon as create.model
     // supports triggers.
-    models.map((model) => ({ create: { model } })).concat(triggers),
+    models
+      .map((model) => ({ create: { model } }))
+      .concat(triggers),
   );
 
   await db.query([...rootModelTransaction.statements, ...modelTransaction.statements]);

--- a/tests/fixtures/utils.ts
+++ b/tests/fixtures/utils.ts
@@ -45,10 +45,10 @@ export const prefillDatabase = async (
   );
 
   const modelTransaction = new Transaction(
-    // @ts-expect-error This is a temporay fix and will be removed as soon as create.model
-    // supports triggers.
     models
       .map((model) => ({ create: { model } }))
+      // @ts-expect-error This is a temporay fix and will be removed as soon as create.model
+      // supports triggers.
       .concat(triggers),
   );
 

--- a/tests/utils/apply.test.ts
+++ b/tests/utils/apply.test.ts
@@ -224,8 +224,7 @@ describe('apply', () => {
     await db.query(statements);
 
     const newModels = await getModels(db);
-
-    expect(newModels[1]?.triggers?.[0]?.action).toBe('DELETE');
+    expect(newModels[0]?.triggers?.[0]?.action).toBe('DELETE');
   });
 
   test('complex model transformation with indexes and triggers', async () => {
@@ -284,6 +283,24 @@ describe('apply', () => {
     const newModels = await getModels(db);
     expect(newModels).toHaveLength(0);
   });
+
+  test('change trigger', async () => {
+    const definedModels: Array<Model> = [TestE];
+    const existingModels: Array<Model> = [TestD];
+
+    const db = await queryEphemeralDatabase(existingModels);
+    const models = await getModels(db);
+    const modelDiff = await diffModels(definedModels, models);
+
+    const protocol = new Protocol(modelDiff);
+    await protocol.convertToQueryObjects();
+
+    const statements = protocol.getSQLStatements(models);
+    await db.query(statements);
+
+    const newModels = await getModels(db);
+    expect(newModels).toHaveLength(1);
+  })
 
   test('complex model update with multiple changes', async () => {
     const definedModels: Array<Model> = [TestE, TestB, Account];

--- a/tests/utils/apply.test.ts
+++ b/tests/utils/apply.test.ts
@@ -300,7 +300,7 @@ describe('apply', () => {
 
     const newModels = await getModels(db);
     expect(newModels).toHaveLength(1);
-  })
+  });
 
   test('complex model update with multiple changes', async () => {
     const definedModels: Array<Model> = [TestE, TestB, Account];

--- a/tests/utils/queries.test.ts
+++ b/tests/utils/queries.test.ts
@@ -69,7 +69,7 @@ describe('queries', () => {
     expect(result).toBe(`alter.model('user').create.field(${JSON.stringify(field)})`);
   });
 
-  test('create field query for link field without target', () => {
+  test('create field query for link field', () => {
     const field: ModelField = {
       slug: 'profile',
       type: 'link',

--- a/tests/utils/queries.test.ts
+++ b/tests/utils/queries.test.ts
@@ -13,7 +13,7 @@ import {
   renameModelQuery,
   setFieldQuery,
 } from '@/src/utils/queries';
-import type { ModelField } from '@ronin/compiler';
+import type { ModelField, ModelTrigger } from '@ronin/compiler';
 
 describe('queries', () => {
   test('drop model query', () => {
@@ -59,6 +59,17 @@ describe('queries', () => {
   });
 
   test('create field query for link field', () => {
+    const field: ModelField = {
+      slug: 'profile',
+      type: 'link',
+      name: 'Profile',
+      target: 'profile',
+    };
+    const result = createFieldQuery('user', field);
+    expect(result).toBe(`alter.model('user').create.field(${JSON.stringify(field)})`);
+  });
+
+  test('create field query for link field without target', () => {
     const field: ModelField = {
       slug: 'profile',
       type: 'link',
@@ -118,6 +129,33 @@ describe('queries', () => {
       ...customQueries,
       'drop.model("user")',
       'alter.model("RONIN_TEMP_user").to({slug: "user"})',
+    ]);
+  });
+
+  test('create temp model query with triggers', () => {
+    const fields: Array<ModelField> = [
+      {
+        slug: 'username',
+        type: 'string',
+        name: 'Username',
+        unique: true,
+        required: true,
+      },
+    ];
+    const triggers: Array<ModelTrigger> = [
+      {
+        action: 'INSERT',
+        when: 'BEFORE',
+        effects: [],
+      },
+    ];
+    const result = createTempModelQuery('user', fields, [], triggers);
+    expect(result).toEqual([
+      "create.model({slug:'RONIN_TEMP_user',fields:[{slug:'username', type:'string', name:'Username', unique:true, required:true}]})",
+      'add.RONIN_TEMP_user.to(() => get.user())',
+      'drop.model("user")',
+      'alter.model("RONIN_TEMP_user").to({slug: "user"})',
+      'alter.model("user").create.trigger({"action":"INSERT","when":"BEFORE","effects":[]})',
     ]);
   });
 


### PR DESCRIPTION
This update ensures that we only consider `field.name` if it is explicitly defined. In SQLite, the name property does not exist; it is only present in the RONIN layer. Therefore, we only need to compare the defined name with the remote name if it is specified. If `field.name` is not defined, it will be automatically generated by the `compiler`. Furthermore, this fix revealed another bug in the tests. The compiler does not yet support a create query with triggers. Therefore, we added a temporary second query to create the triggers separately.