### PR TITLE
Fix duplicate space handles when selecting a space

### DIFF
--- a/src/utils/space.ts
+++ b/src/utils/space.ts
@@ -31,7 +31,12 @@ export const getSpaces = async (
         queries: [
           {
             get: {
-              members: { including: ['space', 'account'] },
+              members: {
+                including: ['space', 'account'],
+                with: {
+                  team: null,
+                },
+              },
             },
           },
         ],


### PR DESCRIPTION
This PR fixes a small bug uncovered where if you are a member of multiple teams in a space the CLI will show the same space handle multiple times when selecting a space for the `apply` or `diff` command.

The way this has been fixed is by updating the query made to get the necessary member records to only include records where the `team` field is `null`.