### PR TITLE
help me

### DIFF
--- a/src/commands/diff.ts
+++ b/src/commands/diff.ts
@@ -21,10 +21,9 @@ export default async (
 ): Promise<void> => {
   let status: Status = 'readingConfig';
   spinner.text = 'Reading configuration';
-  const modelsInCodePath = path.join(
-    process.cwd(),
-    positionals[positionals.indexOf('diff') + 1],
-  );
+  const modelsInCodePath =
+    positionals[positionals.indexOf('diff') + 1] &&
+    path.join(process.cwd(), positionals[positionals.indexOf('diff') + 1]);
 
   const db = await initializeDatabase();
 

--- a/tests/commands/diff.test.ts
+++ b/tests/commands/diff.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, spyOn, test } from 'bun:test';
+import diff from '@/src/commands/diff';
+
+describe('diff', () => {
+  test('run diff command with non existing path to models', async () => {
+    // @ts-ignore This is just a mock!
+    // biome-ignore lint/suspicious/noEmptyBlockStatements: This is just a mock!
+    spyOn(process, 'exit').mockImplementation(() => {});
+
+    try {
+      // @ts-ignore This is just a mock!
+      await diff('appToken', 'sessionToken', { local: true }, ['diff', 'path/to/models']);
+    } catch (err) {
+      expect(err).toThrowError();
+    }
+  });
+
+  test('run diff command with no models file', async () => {
+    // @ts-ignore This is just a mock!
+    // biome-ignore lint/suspicious/noEmptyBlockStatements: This is just a mock!
+    spyOn(process, 'exit').mockImplementation(() => {});
+
+    try {
+      // @ts-ignore This is just a mock!
+      await diff('appToken', 'sessionToken', { local: true }, ['diff']);
+    } catch (err) {
+      expect(err).toThrowError();
+    }
+  });
+});


### PR DESCRIPTION
In [this PR](https://github.com/ronin-co/cli/pull/34), we introduced the ability to pass a custom path for model definitions as an argument to the CLI. However, this change led to a bug where the CLI fails if no path is specified as an argument.