### PR TITLE
Enhanced error message display

### DIFF
--- a/src/commands/apply.ts
+++ b/src/commands/apply.ts
@@ -64,10 +64,7 @@ export default async (
     spinner.succeed('Successfully applied migration');
     process.exit(0);
   } catch (err) {
-    const message =
-      err instanceof RoninError
-        ? err.message
-        : 'Failed to apply migration';
+    const message = err instanceof RoninError ? err.message : 'Failed to apply migration';
     spinner.fail(message);
     spinner.fail(err instanceof Error ? err.message : String(err));
 

--- a/src/commands/apply.ts
+++ b/src/commands/apply.ts
@@ -67,8 +67,9 @@ export default async (
     const message =
       err instanceof RoninError
         ? err.message
-        : `Failed to apply migration: ${err instanceof Error ? err.message : err}`;
+        : 'Failed to apply migration';
     spinner.fail(message);
+    spinner.fail(err instanceof Error ? err.message : String(err));
 
     process.exit(1);
   }
@@ -95,7 +96,7 @@ const applyMigrationStatements = async (
 
   spinner.info('Applying migration to production database');
 
-  await fetch(`https://data.ronin.co/?data-selector=${slug}`, {
+  const response = await fetch(`https://data.ronin.co/?data-selector=${slug}`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -108,4 +109,10 @@ const applyMigrationStatements = async (
       })),
     }),
   });
+
+  const result = (await response.json()) as { error: { message: string } };
+
+  if (!response.ok) {
+    throw new Error(result.error.message);
+  }
 };

--- a/src/utils/field.ts
+++ b/src/utils/field.ts
@@ -41,7 +41,7 @@ export const diffFields = async (
         rename ||
         (await confirm({
           message: `Did you mean to rename field: ${field.from.slug} -> ${field.to.slug}`,
-          default: false,
+          default: true,
         }));
 
       if (confirmRename) {

--- a/src/utils/migration.ts
+++ b/src/utils/migration.ts
@@ -60,7 +60,7 @@ export const diffModels = async (
         (process.env.NODE_ENV !== 'test' &&
           (await confirm({
             message: `Did you mean to rename model: ${model.from.slug} -> ${model.to.slug}`,
-            default: false,
+            default: true,
           })));
 
       if (confirmRename) {


### PR DESCRIPTION
Previously, if the `ronin apply` command failed, the error was not displayed in the terminal, effectively swallowing the error message. This update ensures that errors are now properly passed to the console for visibility. Additionally, the default response for the rename prompt has been changed from "No" to "Yes".