### PR TITLE
Only store space ID in config

### DIFF
--- a/src/commands/apply.ts
+++ b/src/commands/apply.ts
@@ -27,12 +27,12 @@ export default async (
   const db = await initializeDatabase(packages);
 
   try {
-    const spaceId = await getOrSelectSpaceId(sessionToken, spinner);
+    const space = await getOrSelectSpaceId(sessionToken, spinner);
     const existingModels = await getModels(
       packages,
       db,
       appToken ?? sessionToken,
-      spaceId,
+      space,
       flags.local,
     );
     const protocol = await new Protocol(packages).load(migrationFilePath);
@@ -65,7 +65,7 @@ export default async (
       flags,
       db,
       statements,
-      spaceId,
+      space,
     );
 
     spinner.succeed('Successfully applied migration');

--- a/src/commands/apply.ts
+++ b/src/commands/apply.ts
@@ -27,12 +27,12 @@ export default async (
   const db = await initializeDatabase(packages);
 
   try {
-    const { slug } = await getOrSelectSpaceId(sessionToken, spinner);
+    const spaceId = await getOrSelectSpaceId(sessionToken, spinner);
     const existingModels = await getModels(
       packages,
       db,
       appToken ?? sessionToken,
-      slug,
+      spaceId,
       flags.local,
     );
     const protocol = await new Protocol(packages).load(migrationFilePath);
@@ -60,7 +60,13 @@ export default async (
       path.join(migrationsPath, path.basename(latestProtocolFile)),
     );
 
-    await applyMigrationStatements(appToken ?? sessionToken, flags, db, statements, slug);
+    await applyMigrationStatements(
+      appToken ?? sessionToken,
+      flags,
+      db,
+      statements,
+      spaceId,
+    );
 
     spinner.succeed('Successfully applied migration');
     process.exit(0);

--- a/src/commands/diff.ts
+++ b/src/commands/diff.ts
@@ -34,12 +34,12 @@ export default async (
   const db = await initializeDatabase(packages);
 
   try {
-    const { slug } = await getOrSelectSpaceId(sessionToken, spinner);
+    const spaceId = await getOrSelectSpaceId(sessionToken, spinner);
     status = 'comparing';
     spinner.text = 'Comparing models';
 
     const [existingModels, definedModels] = await Promise.all([
-      getModels(packages, db, appToken ?? sessionToken, slug, flags.local),
+      getModels(packages, db, appToken ?? sessionToken, spaceId, flags.local),
       getModelDefinitions(modelsInCodePath),
     ]);
 

--- a/src/commands/diff.ts
+++ b/src/commands/diff.ts
@@ -34,12 +34,12 @@ export default async (
   const db = await initializeDatabase(packages);
 
   try {
-    const spaceId = await getOrSelectSpaceId(sessionToken, spinner);
+    const space = await getOrSelectSpaceId(sessionToken, spinner);
     status = 'comparing';
     spinner.text = 'Comparing models';
 
     const [existingModels, definedModels] = await Promise.all([
-      getModels(packages, db, appToken ?? sessionToken, spaceId, flags.local),
+      getModels(packages, db, appToken ?? sessionToken, space, flags.local),
       getModelDefinitions(modelsInCodePath),
     ]);
 

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -3,7 +3,6 @@ import path from 'node:path';
 
 interface Config {
   spaceId?: string;
-  spaceSlug?: string;
   modelsDir?: string;
 }
 

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 interface Config {
-  spaceId?: string;
+  space?: string;
   modelsDir?: string;
 }
 

--- a/src/utils/model.ts
+++ b/src/utils/model.ts
@@ -14,7 +14,7 @@ import type { Row } from '@ronin/engine/types';
  * @param packages - A list of locally available RONIN packages.
  * @param db - The database instance to query from.
  * @param token - Optional authentication token for production API requests.
- * @param spaceId - Optional space ID for production API requests.
+ * @param space - Optional space ID for production API requests.
  * @param isLocal - Optional flag to determine if production API should be used.
  *
  * @returns Promise resolving to an array of formatted Model objects.
@@ -25,7 +25,7 @@ export const getModels = async (
   packages: LocalPackages,
   db: Database,
   token?: string,
-  spaceId?: string,
+  space?: string,
   isLocal = true,
 ): Promise<Array<Model>> => {
   const { Transaction } = packages.compiler;
@@ -42,7 +42,7 @@ export const getModels = async (
         values: statement.params,
       }));
 
-      const response = await fetch(`https://data.ronin.co/?data-selector=${spaceId}`, {
+      const response = await fetch(`https://data.ronin.co/?data-selector=${space}`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/src/utils/space.ts
+++ b/src/utils/space.ts
@@ -74,10 +74,9 @@ export const getOrSelectSpaceId = async (
   sessionToken?: string,
   spinner?: Ora,
 ): Promise<string> => {
-  const config = readConfig();
-  let spaceId = config.spaceId;
+  let { space } = readConfig();
 
-  if (!spaceId && sessionToken) {
+  if (!space && sessionToken) {
     const spaces = await getSpaces(sessionToken);
 
     if (spaces?.length === 0) {
@@ -89,11 +88,11 @@ export const getOrSelectSpaceId = async (
     }
 
     if (spaces.length === 1) {
-      spaceId = spaces[0].id;
+      space = spaces[0].id;
     } else {
       spinner?.stop();
 
-      spaceId = await select({
+      space = await select({
         message: 'Which space do you want to apply models to?',
         choices: spaces.map((space) => ({
           name: space.handle,
@@ -103,12 +102,12 @@ export const getOrSelectSpaceId = async (
       });
     }
 
-    saveConfig({ spaceId });
+    saveConfig({ space });
   }
 
-  if (!spaceId) {
+  if (!space) {
     throw new Error('Space ID is not specified.');
   }
 
-  return spaceId;
+  return space;
 };


### PR DESCRIPTION
This change ensures that only the ID of the currently selected space is stored in `.ronin`, not its slug.

Additionally, the respective config property is now called `space` instead of `spaceId`, to avoid unnecessary complexity.