### PR TITLE
Do not print spinner for version

### DIFF
--- a/src/utils/info.ts
+++ b/src/utils/info.ts
@@ -1,6 +1,8 @@
+import { spinner } from '@/src/utils/spinner';
 import chalkTemplate from 'chalk-template';
 
 export const printVersion = (version: string): Promise<void> => {
+  spinner.stop();
   console.log(version);
   process.exit(0);
 };


### PR DESCRIPTION
This change prevents the following:

```bash
♥ ~ ronin -v
⠋ 6.0.23
```

Instead, it will now look as expected:

```bash
♥ ~ ronin -v
6.0.23
```

More changes will follow soon that will improve how spinners are handled in general, so that the `printVersion` function no longer needs to stop the spinner. Instead, it should never even be started in the first place, unless it is needed.