### PR TITLE
Skip drop queries for recreated tables in migration

### DIFF
--- a/src/utils/field.ts
+++ b/src/utils/field.ts
@@ -40,7 +40,7 @@ export const diffFields = async (
       const confirmRename =
         rename ||
         (await confirm({
-          message: `Did you mean to rename field: ${field.from.slug} -> ${field.to.slug}`,
+          message: `Did you mean to rename field: ${modelSlug}.${field.from.slug} -> ${modelSlug}.${field.to.slug}`,
           default: true,
         }));
 
@@ -73,8 +73,16 @@ export const diffFields = async (
     }
   }
 
-  diff.push(...createFields(fieldsToAdd, modelSlug, definedFields));
-  diff.push(...deleteFields(fieldsToDelete, modelSlug, definedFields));
+  const createFieldsQueries = createFields(fieldsToAdd, modelSlug, definedFields);
+  diff.push(...createFieldsQueries);
+  if (
+    !(
+      createFieldsQueries.length > 0 &&
+      createFieldsQueries.find((q) => q.includes(RONIN_SCHEMA_TEMP_SUFFIX))
+    )
+  ) {
+    diff.push(...deleteFields(fieldsToDelete, modelSlug, definedFields));
+  }
 
   for (const field of queriesForAdjustment || []) {
     // SQLite's ALTER TABLE is limited - adding UNIQUE or NOT NULL to an existing column

--- a/tests/fixtures/index.ts
+++ b/tests/fixtures/index.ts
@@ -289,3 +289,23 @@ export const TestN = model({
     name: string(),
   },
 }) as unknown as Model;
+
+export const TestO = model({
+  slug: 'test',
+  fields: {
+    name: string(),
+    age: string(),
+    email: string(),
+    bio: string(),
+  },
+}) as unknown as Model;
+
+export const TestP = model({
+  slug: 'test',
+  fields: {
+    name: string(),
+    age: string(),
+    feature: boolean(),
+    description: string({ unique: true }),
+  },
+}) as unknown as Model;

--- a/tests/utils/apply.test.ts
+++ b/tests/utils/apply.test.ts
@@ -16,6 +16,8 @@ import {
   TestL,
   TestM,
   TestN,
+  TestO,
+  TestP,
 } from '@/fixtures/index';
 
 import { describe, expect, test } from 'bun:test';
@@ -500,5 +502,30 @@ describe('apply', () => {
     expect(newModels).toHaveLength(1);
     // @ts-expect-error This is defined!
     expect(newModels[0]?.fields[0]?.type).toBe('string');
+  });
+
+  test('removing field and adding new fields', async () => {
+    const definedModels: Array<Model> = [TestP];
+    const existingModels: Array<Model> = [TestO];
+
+    const db = await queryEphemeralDatabase(existingModels);
+    const packages = await getLocalPackages();
+    const models = await getModels(packages, db);
+
+    const modelDiff = await diffModels(definedModels, models);
+    console.log(modelDiff);
+    expect(modelDiff).toHaveLength(4);
+    const protocol = new Protocol(packages, modelDiff);
+    await protocol.convertToQueryObjects();
+
+    const statements = protocol.getSQLStatements(models);
+    await db.query(statements);
+
+    const newModels = await getModels(packages, db);
+    expect(newModels).toHaveLength(1);
+    // @ts-expect-error This is defined!
+    expect(newModels[0]?.fields[0]?.type).toBe('string');
+    // @ts-expect-error This is defined!
+    expect(newModels[0]?.fields[1]?.type).toBe('string');
   });
 });

--- a/tests/utils/apply.test.ts
+++ b/tests/utils/apply.test.ts
@@ -527,5 +527,7 @@ describe('apply', () => {
     expect(newModels[0]?.fields[0]?.type).toBe('string');
     // @ts-expect-error This is defined!
     expect(newModels[0]?.fields[1]?.type).toBe('string');
+    // @ts-expect-error This is defined!
+    expect(newModels[0]?.fields[3]?.unique).toBe(true);
   });
 });


### PR DESCRIPTION
A customer reported that the migration process created a protocol where a temporary table was generated with the columns already dropped, yet the migration still executed additional drop queries. This has been addressed in this update.

Additionally, I updated the renaming prompt from:
`Did you mean to rename field: name -> notName`
to
`Did you mean to rename field: user.name -> user.notName` for better clarity.