### PR TITLE
Ensure clean query for creating models with no fields

### DIFF
--- a/src/utils/migration.ts
+++ b/src/utils/migration.ts
@@ -146,7 +146,9 @@ export const createModels = (models: Array<Model>): Array<string> => {
   const diff: Array<string> = [];
 
   for (const model of models) {
-    diff.push(createModelQuery(model.slug, { fields: model.fields || [] }));
+    diff.push(
+      createModelQuery(model.slug, model.fields ? { fields: model.fields } : undefined),
+    );
   }
 
   return diff;

--- a/tests/utils/migration.test.ts
+++ b/tests/utils/migration.test.ts
@@ -227,7 +227,7 @@ describe('migration', () => {
       const queries = createModels(models);
 
       expect(queries).toHaveLength(1);
-      expect(queries).toStrictEqual(["create.model({slug:'test1',fields:[]})"]);
+      expect(queries).toStrictEqual(["create.model({slug:'test1'})"]);
     });
 
     test('returns empty array for empty model list', () => {


### PR DESCRIPTION
This change ensures that the query for creating models with no fields is as clean as possible.