### PR TITLE
Fix `diff --apply` with custom path

### DIFF
--- a/src/commands/apply.ts
+++ b/src/commands/apply.ts
@@ -75,7 +75,9 @@ export default async (
         ? err.message
         : 'Failed to apply migration';
     spinner.fail(message);
-    spinner.fail(err instanceof Error ? err.message : String(err));
+    !(err instanceof packages.compiler.RoninError) &&
+      err instanceof Error &&
+      spinner.fail(err.message);
 
     process.exit(1);
   }

--- a/src/commands/apply.ts
+++ b/src/commands/apply.ts
@@ -18,7 +18,7 @@ export default async (
   appToken: string | undefined,
   sessionToken: string | undefined,
   flags: MigrationFlags,
-  migrationFilePath: string,
+  migrationFilePath?: string,
 ): Promise<void> => {
   const spinner = ora('Applying migration').start();
 

--- a/src/commands/diff.ts
+++ b/src/commands/diff.ts
@@ -5,7 +5,6 @@ import { initializeDatabase } from '@/src/utils/database';
 import { type MigrationFlags, diffModels } from '@/src/utils/migration';
 import {
   MODELS_IN_CODE_DIR,
-  MODEL_IN_CODE_PATH,
   getLocalPackages,
   getModelDefinitions,
   logTableDiff,
@@ -82,13 +81,9 @@ export default async (
 
     spinner.succeed('Successfully generated migration protocol file');
 
-    const migrationFilePath = positionals?.[positionals.indexOf('diff') + 1]
-      ? path.join(process.cwd(), positionals[positionals.indexOf('diff') + 1])
-      : MODEL_IN_CODE_PATH;
-
     // If desired, immediately apply the migration
     if (flags.apply) {
-      await apply(appToken, sessionToken, flags, migrationFilePath);
+      await apply(appToken, sessionToken, flags);
     }
 
     process.exit(0);


### PR DESCRIPTION
This PR fixes a regression introduced in [PR #47](https://github.com/ronin-co/cli/pull/47) that affected the `diff --apply` command. Additionally, I noticed that some errors were being printed twice in the console, which has also been addressed.

![image](https://github.com/user-attachments/assets/eb058947-26ff-465c-abc1-db3e6f9fc7ee)
