### PR TITLE
Allow to alter link fields of kind `many`

### DIFF
--- a/src/utils/field.ts
+++ b/src/utils/field.ts
@@ -91,6 +91,8 @@ export const diffFields = async (
     const existingField = existingFields.find((f) => f.slug === field.slug);
     if (field.unique || field.required || existingField?.unique) {
       diff.push(...adjustFields(modelSlug, definedFields, indexes, triggers));
+    } else if (field.type === 'link' && field.kind === 'many') {
+      diff.push(...adjustFields(modelSlug, definedFields, indexes, triggers));
     } else {
       diff.push(...createTempColumnQuery(modelSlug, field, indexes, triggers));
     }

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -148,7 +148,8 @@ export const formatSqliteStatement = (statement: string): string => {
 };
 
 /**
- * Adds ANSI color codes to SQL keywords, table names, and string literals for console output.
+ * Adds ANSI color codes to SQL keywords, table names, and string literals for console
+ * output.
  *
  * @param sql - The SQL statement to colorize.
  * @returns The SQL statement with ANSI color codes added.

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -81,3 +81,96 @@ export const formatCode = (code: string): Promise<string> => {
     semi: config.semi,
   });
 };
+
+/**
+ * Formats a SQLite statement by adding proper indentation and line breaks.
+ * Also applies syntax highlighting for console output.
+ *
+ * @param statement - The SQLite statement to format
+ * @returns The formatted and colorized SQL statement as a string
+ *
+ * @example
+ * ```typescript
+ * formatSqliteStatement('CREATE TABLE "users" (id INTEGER PRIMARY KEY, name TEXT)')
+ * // Returns colorized:
+ * // CREATE TABLE "users" (
+ * //   id INTEGER PRIMARY KEY,
+ * //   name TEXT
+ * // );
+ * ```
+ */
+export const formatSqliteStatement = (statement: string): string => {
+  if (statement.startsWith('CREATE TABLE')) {
+    const match = statement.match(/CREATE TABLE "(.*?)" \((.*)\)/s);
+    if (match) {
+      const tableName = match[1];
+      const columns = match[2]
+        .split(/,(?= ")/) // Split only at commas followed by space and quotes
+        .map((col, index) => (index === 0 ? col.trim() : `\n  ${col.trim()}`)) // Indent all but first line
+        .join(', '); // Join with a comma and space for correct formatting
+
+      return colorizeSql(`CREATE TABLE "${tableName}" (\n  ${columns}\n);`);
+    }
+  }
+
+  if (statement.startsWith('ALTER TABLE')) {
+    const match = statement.match(/ALTER TABLE "(.*?)" ADD COLUMN "(.*?)" (.*)/);
+    if (match) {
+      return colorizeSql(
+        `ALTER TABLE "${match[1]}"\n  ADD COLUMN "${match[2]}" ${match[3]};`,
+      );
+    }
+  }
+
+  if (statement.startsWith('UPDATE')) {
+    const match = statement.match(/UPDATE "(.*?)" SET (.*?) RETURNING (.*)/);
+    if (match) {
+      return colorizeSql(`UPDATE "${match[1]}"\nSET ${match[2]}\nRETURNING ${match[3]};`);
+    }
+  }
+
+  if (statement.startsWith('DROP TABLE')) {
+    const match = statement.match(/DROP TABLE "(.*?)"/);
+    if (match) {
+      return colorizeSql(`DROP TABLE "${match[1]}";`);
+    }
+  }
+
+  if (statement.startsWith('INSERT INTO')) {
+    const match = statement.match(/INSERT INTO "(.*?)" \((.*?)\)(.*)/);
+    if (match) {
+      return colorizeSql(`INSERT INTO "${match[1]}"\n  (${match[2]})\n${match[3]};`);
+    }
+  }
+
+  return colorizeSql(statement);
+};
+
+/**
+ * Adds ANSI color codes to SQL keywords, table names, and string literals for console output.
+ *
+ * @param sql - The SQL statement to colorize.
+ * @returns The SQL statement with ANSI color codes added.
+ *
+ * @example
+ * ```typescript
+ * colorizeSql('SELECT * FROM "users"')
+ * // Returns string with ANSI codes for yellow keywords and cyan table names
+ * ```
+ */
+export const colorizeSql = (sql: string): string => {
+  const colors = {
+    keyword: '\x1b[1;33m', // Bold Yellow
+    table: '\x1b[1;36m', // Bold Cyan
+    string: '\x1b[1;32m', // Bold Green
+    reset: '\x1b[0m', // Reset color
+  };
+
+  return sql
+    .replace(
+      /\b(CREATE|TABLE|ALTER|ADD|COLUMN|INSERT|INTO|SELECT|TEXT|BOOLEAN|DATETIME|DEFAULT|UPDATE|SET|RETURNING|DROP|ON DELETE|ON UPDATE|PRIMARY KEY|REFERENCES)\b/g,
+      `${colors.keyword}$1${colors.reset}`,
+    )
+    .replace(/"([^"]+)"/g, `${colors.table}"$1"${colors.reset}`) // Table & column names
+    .replace(/'([^']+)'/g, `${colors.string}'$1'${colors.reset}`); // String literals
+};

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -86,8 +86,9 @@ export const formatCode = (code: string): Promise<string> => {
  * Formats a SQLite statement by adding proper indentation and line breaks.
  * Also applies syntax highlighting for console output.
  *
- * @param statement - The SQLite statement to format
- * @returns The formatted and colorized SQL statement as a string
+ * @param statement - The SQLite statement to format.
+ *
+ * @returns The formatted and colorized SQL statement as a string.
  *
  * @example
  * ```typescript

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -151,6 +151,7 @@ export const formatSqliteStatement = (statement: string): string => {
  * Adds ANSI color codes to SQL keywords, table names, and string literals for console
  * output.
  *
+ *
  * @param sql - The SQL statement to colorize.
  * @returns The SQL statement with ANSI color codes added.
  *

--- a/tests/fixtures/index.ts
+++ b/tests/fixtures/index.ts
@@ -309,3 +309,44 @@ export const TestP = model({
     description: string({ unique: true }),
   },
 }) as unknown as Model;
+
+export const TestQ = model({
+  slug: 'many',
+  fields: {
+    name: string(),
+    test: link({ target: 'test', kind: 'many', actions: { onDelete: 'CASCADE' } }),
+  },
+}) as unknown as Model;
+
+export const TestR = model({
+  slug: 'many',
+  fields: {
+    name: string(),
+    test: link({
+      target: 'test',
+      kind: 'many',
+      actions: { onDelete: 'CASCADE', onUpdate: 'CASCADE' },
+    }),
+  },
+}) as unknown as Model;
+
+export const TestS = model({
+  slug: 'many',
+  fields: {
+    name: string(),
+    test: link({
+      target: 'test',
+      kind: 'many',
+      actions: { onDelete: 'CASCADE', onUpdate: 'CASCADE' },
+    }),
+    email: string(),
+  },
+}) as unknown as Model;
+
+export const TestT = model({
+  slug: 'many',
+  fields: {
+    name: string(),
+    email: string(),
+  },
+}) as unknown as Model;

--- a/tests/fixtures/utils.ts
+++ b/tests/fixtures/utils.ts
@@ -1,6 +1,5 @@
-import { getLocalPackages } from '@/src/utils/misc';
-
 import { diffModels } from '@/src/utils/migration';
+import { getLocalPackages } from '@/src/utils/misc';
 import { getModels } from '@/src/utils/model';
 import { Protocol } from '@/src/utils/protocol';
 import type { Model } from '@ronin/compiler';
@@ -69,6 +68,7 @@ export async function runMigration(
   enableRename = false,
 ) {
   const db = await queryEphemeralDatabase(existingModels);
+
   const packages = await getLocalPackages();
   const models = await getModels(packages, db);
 
@@ -77,6 +77,7 @@ export async function runMigration(
   await protocol.convertToQueryObjects();
 
   const statements = protocol.getSQLStatements(models);
+
   await db.query(statements);
 
   return {

--- a/tests/fixtures/utils.ts
+++ b/tests/fixtures/utils.ts
@@ -1,5 +1,8 @@
 import { getLocalPackages } from '@/src/utils/misc';
 
+import { diffModels } from '@/src/utils/migration';
+import { getModels } from '@/src/utils/model';
+import { Protocol } from '@/src/utils/protocol';
 import type { Model } from '@ronin/compiler';
 import { type Database, Engine } from '@ronin/engine';
 import { MemoryResolver } from '@ronin/engine/resolvers/memory';
@@ -45,3 +48,54 @@ export const prefillDatabase = async (
 
   await db.query([...rootModelTransaction.statements, ...modelTransaction.statements]);
 };
+
+/**
+ * Runs a migration by comparing defined models against existing models and applying the differences.
+ *
+ * @param definedModels - The new/updated model definitions to migrate to.
+ * @param existingModels - The current models in the database.
+ * @param enableRename - Whether to enable model renaming during migration (defaults to false).
+ *
+ * @returns Object containing:
+ *   - db: The ephemeral database instance.
+ *   - packages: The loaded package dependencies.
+ *   - models: The resulting models after migration.
+ *   - statements: The SQL statements that were executed.
+ *   - modelDiff: The computed differences between defined and existing models.
+ */
+export async function runMigration(
+  definedModels: Array<Model>,
+  existingModels: Array<Model>,
+  enableRename = false,
+) {
+  const db = await queryEphemeralDatabase(existingModels);
+  const packages = await getLocalPackages();
+  const models = await getModels(packages, db);
+
+  const modelDiff = await diffModels(definedModels, models, enableRename);
+  const protocol = new Protocol(packages, modelDiff);
+  await protocol.convertToQueryObjects();
+
+  const statements = protocol.getSQLStatements(models);
+  await db.query(statements);
+
+  return {
+    db,
+    packages,
+    models: await getModels(packages, db),
+    statements,
+    modelDiff,
+  };
+}
+
+/**
+ * Retrieves a list of all table names from a SQLite database.
+ *
+ * @param db - The database instance to query.
+ *
+ * @returns A list of table names mapped from the query results.
+ */
+export async function getSQLTables(db: Database) {
+  const res = await db.query(['SELECT name FROM sqlite_master WHERE type="table";']);
+  return res[0].rows;
+}

--- a/tests/fixtures/utils.ts
+++ b/tests/fixtures/utils.ts
@@ -53,7 +53,7 @@ export const prefillDatabase = async (
  *
  * @param definedModels - The new/updated model definitions to migrate to.
  * @param existingModels - The current models in the database.
- * @param enableRename - Whether to enable model renaming during migration (defaults to false).
+ * @param enableRename - Whether to enable model renaming during migration (defaults to `false`).
  *
  * @returns Object containing:
  *   - db: The ephemeral database instance.

--- a/tests/fixtures/utils.ts
+++ b/tests/fixtures/utils.ts
@@ -49,7 +49,8 @@ export const prefillDatabase = async (
 };
 
 /**
- * Runs a migration by comparing defined models against existing models and applying the differences.
+ * Runs a migration by comparing defined models against existing models and applying
+ * the differences.
  *
  * @param definedModels - The new/updated model definitions to migrate to.
  * @param existingModels - The current models in the database.

--- a/tests/utils/apply.test.ts
+++ b/tests/utils/apply.test.ts
@@ -209,10 +209,7 @@ describe('apply', () => {
     });
 
     test('update model with many-to-many relationship', async () => {
-      const { models, db } = await runMigration(
-        [TestP, TestR],
-        [TestP, TestQ],
-      );
+      const { models, db } = await runMigration([TestP, TestR], [TestP, TestQ]);
 
       const res = await getSQLTables(db);
 

--- a/tests/utils/apply.test.ts
+++ b/tests/utils/apply.test.ts
@@ -209,7 +209,7 @@ describe('apply', () => {
     });
 
     test('update model with many-to-many relationship', async () => {
-      const { models, db, modelDiff } = await runMigration(
+      const { models, db } = await runMigration(
         [TestP, TestR],
         [TestP, TestQ],
       );

--- a/tests/utils/apply.test.ts
+++ b/tests/utils/apply.test.ts
@@ -215,22 +215,17 @@ describe('apply', () => {
       );
 
       const res = await getSQLTables(db);
-      console.log(res);
-      console.log(modelDiff);
-      expect(res).toHaveLength(4);
+
+      expect(res).toHaveLength(5);
       expect(models).toHaveLength(2);
     });
 
-    test.only('add field to model with many-to-many relationship', async () => {
-      const { models, db, modelDiff } = await runMigration(
-        [TestP, TestS],
-        [TestP, TestQ],
-      );
+    test('add field to model with many-to-many relationship', async () => {
+      const { models, db } = await runMigration([TestP, TestS], [TestP, TestQ]);
 
       const res = await getSQLTables(db);
-      console.log(res);
-      console.log(modelDiff);
-      expect(res).toHaveLength(4);
+
+      expect(res).toHaveLength(5);
       expect(models).toHaveLength(2);
     });
 

--- a/tests/utils/apply.test.ts
+++ b/tests/utils/apply.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from 'bun:test';
 import {
   Account,
   AccountNew,
@@ -18,516 +19,247 @@ import {
   TestN,
   TestO,
   TestP,
+  TestQ,
+  TestR,
+  TestS,
+  TestT,
 } from '@/fixtures/index';
-
-import { describe, expect, test } from 'bun:test';
-import { queryEphemeralDatabase } from '@/fixtures/utils';
-import { diffModels } from '@/src/utils/migration';
-import { getLocalPackages } from '@/src/utils/misc';
-import { getModels } from '@/src/utils/model';
-import { Protocol } from '@/src/utils/protocol';
-import type { Model } from '@ronin/compiler';
+import { getSQLTables, runMigration } from '@/fixtures/utils';
 
 describe('apply', () => {
-  test('create a model', async () => {
-    const definedModels: Array<Model> = [TestA];
-    const existingModels: Array<Model> = [];
+  describe('model', () => {
+    test('create a model', async () => {
+      const { models, statements } = await runMigration([TestA], []);
 
-    const modelDiff = await diffModels(definedModels, existingModels);
-    const packages = await getLocalPackages();
-    const protocol = new Protocol(packages, modelDiff);
-    await protocol.convertToQueryObjects();
+      expect(statements).toHaveLength(4);
+      expect(models).toHaveLength(1);
+      expect(models[0].slug).toBe('test');
+    });
 
-    const statements = protocol.getSQLStatements(existingModels);
-    expect(statements).toHaveLength(4);
+    test('drop a model', async () => {
+      const { models, statements } = await runMigration([], [TestA]);
 
-    const db = await queryEphemeralDatabase(existingModels);
-    await db.query(statements);
+      expect(statements).toHaveLength(2);
+      expect(models).toHaveLength(0);
+    });
 
-    expect(db).toBeDefined();
+    test('update a model', async () => {
+      const { models, statements } = await runMigration([TestF], [TestA]);
 
-    const models = await getModels(packages, db);
+      expect(statements).toHaveLength(7);
+      expect(models).toHaveLength(1);
+      expect(models[0].slug).toBe('test');
+    });
 
-    expect(models).toHaveLength(1);
-    expect(models[0].slug).toBe('test');
+    test('update model meta properties', async () => {
+      const { models } = await runMigration([TestC], [TestA]);
+
+      expect(models).toHaveLength(1);
+      expect(models[0].name).toBe('ThisIsACoolModel');
+    });
+
+    test('drop multiple models with dependencies', async () => {
+      const { models } = await runMigration([], [Account, Profile, TestA]);
+
+      expect(models).toHaveLength(0);
+    });
+
+    test('migrate with no changes between model sets', async () => {
+      const allModels = [TestG, Account, AccountNew, Profile];
+      const { models } = await runMigration(allModels, allModels);
+
+      expect(models.length).toBe(allModels.length);
+    });
+  });
+  describe('field', () => {
+    test('add field and change field property', async () => {
+      const { models } = await runMigration([TestG], [TestF]);
+
+      expect(models).toHaveLength(1);
+    });
+
+    test('change field type', async () => {
+      const { models } = await runMigration([TestM], [TestL]);
+
+      expect(models).toHaveLength(1);
+      // @ts-expect-error This is defined!
+      expect(models[0]?.fields[1]?.type).toBe('json');
+    });
+
+    test('adding a unique field', async () => {
+      const { models } = await runMigration([TestG], [TestN]);
+
+      expect(models).toHaveLength(1);
+      // @ts-expect-error This is defined!
+      expect(models[0]?.fields[0]?.unique).toBe(true);
+    });
+
+    test('removing a unique field', async () => {
+      const { models } = await runMigration([TestN], [TestG]);
+
+      expect(models).toHaveLength(1);
+      // @ts-expect-error This is defined!
+      expect(models[0]?.fields[0]?.type).toBe('string');
+    });
+
+    test('removing field and adding new fields', async () => {
+      const { models, modelDiff } = await runMigration([TestP], [TestO]);
+
+      expect(modelDiff).toHaveLength(4);
+      expect(models).toHaveLength(1);
+      // @ts-expect-error This is defined!
+      expect(models[0]?.fields[0]?.type).toBe('string');
+      // @ts-expect-error This is defined!
+      expect(models[0]?.fields[1]?.type).toBe('string');
+      // @ts-expect-error This is defined!
+      expect(models[0]?.fields[3]?.unique).toBe(true);
+    });
+  });
+  describe('rename', () => {
+    test('update a model - rename', async () => {
+      const { models, statements } = await runMigration([Account], [AccountNew], true);
+
+      expect(statements).toHaveLength(2);
+      expect(models).toHaveLength(1);
+      expect(models[0].slug).toBe('account');
+    });
+
+    test('rename model with existing relationships', async () => {
+      const { models } = await runMigration(
+        [AccountNew, Profile],
+        [Account, Profile],
+        true,
+      );
+
+      expect(models.find((m) => m.slug === 'account_new')).toBeDefined();
+    });
+
+    test('create model with field rename', async () => {
+      const { models } = await runMigration([TestI], [TestH], true);
+
+      expect(models).toHaveLength(1);
+    });
+  });
+  describe('index', () => {
+    test('create a model with index', async () => {
+      const { models, statements } = await runMigration([TestB], []);
+
+      expect(statements).toHaveLength(4);
+      expect(models).toHaveLength(1);
+      expect(models[0].slug).toBe('test');
+    });
+
+    test('drop model with index', async () => {
+      const { models, statements } = await runMigration([], [TestB]);
+
+      expect(statements).toHaveLength(2);
+      expect(models).toHaveLength(0);
+    });
+  });
+  describe('trigger', () => {
+    test('create model with triggers', async () => {
+      const { models } = await runMigration([TestC, TestD], []);
+
+      expect(models).toHaveLength(2);
+      expect(models[0].triggers).toBeDefined();
+    });
+
+    test('update model triggers', async () => {
+      const { models } = await runMigration([TestE, TestC], [TestD]);
+
+      expect(models).toHaveLength(2);
+      expect(models[0]?.triggers?.[0]?.action).toBe('DELETE');
+    });
+
+    test('complex model transformation with indexes and triggers', async () => {
+      const { models } = await runMigration([TestE, TestB], [TestD, TestA]);
+
+      expect(models).toHaveLength(2);
+    });
+    test('change trigger', async () => {
+      const { models } = await runMigration([TestE], [TestD]);
+
+      expect(models).toHaveLength(1);
+      expect(models[0]?.triggers?.[0]?.action).toBe('DELETE');
+      expect(models[0]?.triggers?.[0]?.when).toBe('AFTER');
+    });
+  });
+  describe('relationship', () => {
+    test('create multiple models with relationships', async () => {
+      const { models, statements } = await runMigration([Account, Profile], []);
+
+      expect(statements.length).toEqual(4);
+      expect(models).toHaveLength(2);
+    });
+    test('create model with link cascade', async () => {
+      const { models } = await runMigration([TestE, TestK], [TestE, TestJ]);
+
+      expect(models).toHaveLength(2);
+      // @ts-expect-error This is defined!
+      expect(models[1]?.fields[0]?.actions?.onDelete).toBe('CASCADE');
+    });
+
+    test('create model with many-to-many relationship', async () => {
+      const { models, db } = await runMigration([TestP, TestQ], []);
+
+      const res = await getSQLTables(db);
+
+      expect(res).toHaveLength(4);
+      expect(models).toHaveLength(2);
+    });
+
+    test('update model with many-to-many relationship', async () => {
+      const { models, db, modelDiff } = await runMigration(
+        [TestP, TestR],
+        [TestP, TestQ],
+      );
+
+      const res = await getSQLTables(db);
+      console.log(res);
+      console.log(modelDiff);
+      expect(res).toHaveLength(4);
+      expect(models).toHaveLength(2);
+    });
+
+    test.only('add field to model with many-to-many relationship', async () => {
+      const { models, db, modelDiff } = await runMigration(
+        [TestP, TestS],
+        [TestP, TestQ],
+      );
+
+      const res = await getSQLTables(db);
+      console.log(res);
+      console.log(modelDiff);
+      expect(res).toHaveLength(4);
+      expect(models).toHaveLength(2);
+    });
+
+    test('remove many-to-many relationship', async () => {
+      const { models, db } = await runMigration([TestP, TestT], [TestP, TestQ]);
+
+      const res = await getSQLTables(db);
+
+      expect(res).toHaveLength(3);
+      expect(models).toHaveLength(2);
+    });
   });
 
-  test('drop a model', async () => {
-    const definedModels: Array<Model> = [];
-    const existingModels: Array<Model> = [TestA];
+  describe('complex', () => {
+    test('complex model update with multiple changes', async () => {
+      const { models } = await runMigration(
+        [TestE, TestB, Account],
+        [TestD, TestA, AccountNew],
+        true,
+      );
 
-    const modelDiff = await diffModels(definedModels, existingModels);
-    const packages = await getLocalPackages();
-    const protocol = new Protocol(packages, modelDiff);
-    await protocol.convertToQueryObjects();
+      expect(models).toHaveLength(3);
+    });
 
-    const statements = protocol.getSQLStatements(existingModels);
-    expect(statements).toHaveLength(2);
+    test('create and update models with mixed operations', async () => {
+      const { models } = await runMigration([TestB, TestE, Account], [TestA, TestD]);
 
-    const db = await queryEphemeralDatabase(existingModels);
-    await db.query(statements);
-
-    expect(db).toBeDefined();
-
-    const models = await getModels(packages, db);
-
-    expect(models).toHaveLength(0);
+      expect(models.length).toBeGreaterThan(1);
+    });
   });
-
-  test('create a model with index', async () => {
-    const definedModels: Array<Model> = [TestB];
-    const existingModels: Array<Model> = [];
-
-    const modelDiff = await diffModels(definedModels, existingModels);
-    const packages = await getLocalPackages();
-    const protocol = new Protocol(packages, modelDiff);
-    await protocol.convertToQueryObjects();
-
-    const statements = protocol.getSQLStatements(existingModels);
-    expect(statements).toHaveLength(4);
-
-    const db = await queryEphemeralDatabase(existingModels);
-    await db.query(statements);
-
-    expect(db).toBeDefined();
-
-    const models = await getModels(packages, db);
-
-    expect(models).toHaveLength(1);
-    expect(models[0].slug).toBe('test');
-  });
-
-  test('drop model with index', async () => {
-    const definedModels: Array<Model> = [];
-    const existingModels: Array<Model> = [TestB];
-
-    const modelDiff = await diffModels(definedModels, existingModels);
-    const packages = await getLocalPackages();
-    const protocol = new Protocol(packages, modelDiff);
-    await protocol.convertToQueryObjects();
-
-    const statements = protocol.getSQLStatements(existingModels);
-    expect(statements).toHaveLength(2);
-
-    const db = await queryEphemeralDatabase(existingModels);
-    await db.query(statements);
-
-    expect(db).toBeDefined();
-
-    const models = await getModels(packages, db);
-
-    expect(models).toHaveLength(0);
-  });
-
-  test('update a model', async () => {
-    const definedModels: Array<Model> = [TestF];
-    const existingModels: Array<Model> = [TestA];
-
-    const modelDiff = await diffModels(definedModels, existingModels);
-    const packages = await getLocalPackages();
-    const protocol = new Protocol(packages, modelDiff);
-    await protocol.convertToQueryObjects();
-
-    const statements = protocol.getSQLStatements(existingModels);
-
-    expect(statements).toHaveLength(7);
-
-    const db = await queryEphemeralDatabase(existingModels);
-
-    expect(db).toBeDefined();
-
-    await db.query(statements);
-
-    const models = await getModels(packages, db);
-
-    expect(models).toHaveLength(1);
-    expect(models[0].slug).toBe('test');
-  });
-
-  test('update a model - rename', async () => {
-    const definedModels: Array<Model> = [Account];
-    const existingModels: Array<Model> = [AccountNew];
-
-    const modelDiff = await diffModels(definedModels, existingModels, true);
-    const packages = await getLocalPackages();
-    const protocol = new Protocol(packages, modelDiff);
-    await protocol.convertToQueryObjects();
-
-    const statements = protocol.getSQLStatements(existingModels);
-
-    expect(statements).toHaveLength(2);
-
-    const db = await queryEphemeralDatabase(existingModels);
-
-    expect(db).toBeDefined();
-
-    await db.query(statements);
-
-    const models = await getModels(packages, db);
-
-    expect(models).toHaveLength(1);
-    expect(models[0].slug).toBe('account');
-  });
-
-  test('create multiple models with relationships', async () => {
-    const definedModels: Array<Model> = [Account, Profile];
-    const existingModels: Array<Model> = [];
-
-    const modelDiff = await diffModels(definedModels, existingModels);
-    const packages = await getLocalPackages();
-    const protocol = new Protocol(packages, modelDiff);
-    await protocol.convertToQueryObjects();
-
-    const statements = protocol.getSQLStatements(existingModels);
-    expect(statements.length).toEqual(4);
-
-    const db = await queryEphemeralDatabase(existingModels);
-    await db.query(statements);
-
-    const models = await getModels(packages, db);
-    expect(models).toHaveLength(2);
-  });
-
-  test('update model meta properties', async () => {
-    const definedModels: Array<Model> = [TestC];
-    const existingModels: Array<Model> = [TestA];
-
-    const modelDiff = await diffModels(definedModels, existingModels);
-    const packages = await getLocalPackages();
-    const protocol = new Protocol(packages, modelDiff);
-    await protocol.convertToQueryObjects();
-
-    const statements = protocol.getSQLStatements(existingModels);
-    const db = await queryEphemeralDatabase(existingModels);
-    await db.query(statements);
-
-    const models = await getModels(packages, db);
-    expect(models[0].name).toBe('ThisIsACoolModel');
-  });
-
-  test('create model with triggers', async () => {
-    const definedModels: Array<Model> = [TestC, TestD];
-    const existingModels: Array<Model> = [];
-
-    const modelDiff = await diffModels(definedModels, existingModels);
-    const packages = await getLocalPackages();
-    const protocol = new Protocol(packages, modelDiff);
-    await protocol.convertToQueryObjects();
-
-    const statements = protocol.getSQLStatements(existingModels);
-
-    const db = await queryEphemeralDatabase(existingModels);
-
-    await db.query(statements);
-
-    const models = await getModels(packages, db);
-    expect(models).toHaveLength(2);
-    expect(models[0].triggers).toBeDefined();
-  });
-
-  test('update model triggers', async () => {
-    const definedModels: Array<Model> = [TestE, TestC];
-    const existingModels: Array<Model> = [TestD];
-
-    const db = await queryEphemeralDatabase(existingModels);
-    const packages = await getLocalPackages();
-    const models = await getModels(packages, db);
-
-    const modelDiff = await diffModels(definedModels, models);
-
-    const protocol = new Protocol(packages, modelDiff);
-    await protocol.convertToQueryObjects();
-
-    const statements = protocol.getSQLStatements(models);
-    await db.query(statements);
-
-    const newModels = await getModels(packages, db);
-    expect(newModels[0]?.triggers?.[0]?.action).toBe('DELETE');
-  });
-
-  test('complex model transformation with indexes and triggers', async () => {
-    const definedModels: Array<Model> = [TestE, TestB];
-    const existingModels: Array<Model> = [TestD, TestA];
-
-    const db = await queryEphemeralDatabase(existingModels);
-    const packages = await getLocalPackages();
-    const models = await getModels(packages, db);
-
-    const modelDiff = await diffModels(definedModels, models);
-
-    const protocol = new Protocol(packages, modelDiff);
-    await protocol.convertToQueryObjects();
-
-    const statements = protocol.getSQLStatements(models);
-    await db.query(statements);
-
-    const newModels = await getModels(packages, db);
-    expect(newModels).toHaveLength(2);
-  });
-
-  test('rename model with existing relationships', async () => {
-    const definedModels: Array<Model> = [AccountNew, Profile];
-    const existingModels: Array<Model> = [Account, Profile];
-
-    const db = await queryEphemeralDatabase(existingModels);
-    const packages = await getLocalPackages();
-    const models = await getModels(packages, db);
-
-    const modelDiff = await diffModels(definedModels, models, true);
-
-    const protocol = new Protocol(packages, modelDiff);
-    await protocol.convertToQueryObjects();
-
-    const statements = protocol.getSQLStatements(models);
-    await db.query(statements);
-
-    const newModels = await getModels(packages, db);
-    expect(newModels.find((m) => m.slug === 'account_new')).toBeDefined();
-  });
-
-  test('drop multiple models with dependencies', async () => {
-    const definedModels: Array<Model> = [];
-    const existingModels: Array<Model> = [Account, Profile, TestA];
-
-    const db = await queryEphemeralDatabase(existingModels);
-    const packages = await getLocalPackages();
-    const models = await getModels(packages, db);
-
-    const modelDiff = await diffModels(definedModels, models);
-
-    const protocol = new Protocol(packages, modelDiff);
-    await protocol.convertToQueryObjects();
-
-    const statements = protocol.getSQLStatements(models);
-    await db.query(statements);
-
-    const newModels = await getModels(packages, db);
-    expect(newModels).toHaveLength(0);
-  });
-
-  test('change trigger', async () => {
-    const definedModels: Array<Model> = [TestE];
-    const existingModels: Array<Model> = [TestD];
-
-    const db = await queryEphemeralDatabase(existingModels);
-    const packages = await getLocalPackages();
-    const models = await getModels(packages, db);
-    const modelDiff = await diffModels(definedModels, models);
-
-    const protocol = new Protocol(packages, modelDiff);
-    await protocol.convertToQueryObjects();
-
-    const statements = protocol.getSQLStatements(models);
-    await db.query(statements);
-
-    const newModels = await getModels(packages, db);
-    expect(newModels).toHaveLength(1);
-  });
-
-  test('complex model update with multiple changes', async () => {
-    const definedModels: Array<Model> = [TestE, TestB, Account];
-    const existingModels: Array<Model> = [TestD, TestA, AccountNew];
-
-    const db = await queryEphemeralDatabase(existingModels);
-    const packages = await getLocalPackages();
-    const models = await getModels(packages, db);
-
-    const modelDiff = await diffModels(definedModels, models, true);
-
-    const protocol = new Protocol(packages, modelDiff);
-    await protocol.convertToQueryObjects();
-
-    const statements = protocol.getSQLStatements(models);
-    await db.query(statements);
-
-    const newModels = await getModels(packages, db);
-    expect(newModels).toHaveLength(3);
-  });
-
-  test('create and update models with mixed operations', async () => {
-    const definedModels: Array<Model> = [TestB, TestE, Account];
-    const existingModels: Array<Model> = [TestA, TestD];
-    const db = await queryEphemeralDatabase(existingModels);
-    const packages = await getLocalPackages();
-    const models = await getModels(packages, db);
-
-    const modelDiff = await diffModels(definedModels, models);
-
-    const protocol = new Protocol(packages, modelDiff);
-    await protocol.convertToQueryObjects();
-
-    const statements = protocol.getSQLStatements(models);
-    await db.query(statements);
-
-    const newModels = await getModels(packages, db);
-    expect(newModels.length).toBeGreaterThan(1);
-  });
-
-  test('add field and change field property', async () => {
-    const definedModels: Array<Model> = [TestG];
-    const existingModels: Array<Model> = [TestF];
-
-    const db = await queryEphemeralDatabase(existingModels);
-    const packages = await getLocalPackages();
-    const models = await getModels(packages, db);
-
-    const modelDiff = await diffModels(definedModels, models);
-    const protocol = new Protocol(packages, modelDiff);
-    await protocol.convertToQueryObjects();
-
-    const statements = protocol.getSQLStatements(models);
-    await db.query(statements);
-
-    const newModels = await getModels(packages, db);
-    expect(newModels).toHaveLength(1);
-  });
-
-  test('migrate with no changes between model sets', async () => {
-    const allModels = [TestG, Account, AccountNew, Profile];
-    const db = await queryEphemeralDatabase(allModels);
-    const packages = await getLocalPackages();
-    const models = await getModels(packages, db);
-
-    const modelDiff = await diffModels(allModels, models);
-    const protocol = new Protocol(packages, modelDiff);
-    await protocol.convertToQueryObjects();
-
-    const statements = protocol.getSQLStatements(models);
-    await db.query(statements);
-
-    const newModels = await getModels(packages, db);
-    expect(newModels.length).toBe(allModels.length);
-  });
-
-  test('create model with field rename', async () => {
-    const definedModels: Array<Model> = [TestI];
-    const existingModels: Array<Model> = [TestH];
-
-    const db = await queryEphemeralDatabase(existingModels);
-    const packages = await getLocalPackages();
-    const models = await getModels(packages, db);
-
-    const modelDiff = await diffModels(definedModels, models, true);
-
-    const protocol = new Protocol(packages, modelDiff);
-    await protocol.convertToQueryObjects();
-
-    const statements = protocol.getSQLStatements(models);
-    await db.query(statements);
-
-    const newModels = await getModels(packages, db);
-    expect(newModels).toHaveLength(1);
-  });
-
-  test('create model with link cascade', async () => {
-    const definedModels: Array<Model> = [TestE, TestK];
-    const existingModels: Array<Model> = [TestE, TestJ];
-
-    const db = await queryEphemeralDatabase(existingModels);
-    const packages = await getLocalPackages();
-    const models = await getModels(packages, db);
-
-    const modelDiff = await diffModels(definedModels, models);
-    const protocol = new Protocol(packages, modelDiff);
-    await protocol.convertToQueryObjects();
-
-    const statements = protocol.getSQLStatements(models);
-    await db.query(statements);
-
-    const newModels = await getModels(packages, db);
-    expect(newModels).toHaveLength(2);
-    // @ts-expect-error This is defined!
-    expect(newModels[1]?.fields[0]?.actions?.onDelete).toBe('CASCADE');
-  });
-
-  test('change field type', async () => {
-    const definedModels: Array<Model> = [TestM];
-    const existingModels: Array<Model> = [TestL];
-
-    const db = await queryEphemeralDatabase(existingModels);
-    const packages = await getLocalPackages();
-    const models = await getModels(packages, db);
-
-    const modelDiff = await diffModels(definedModels, models);
-    const protocol = new Protocol(packages, modelDiff);
-    await protocol.convertToQueryObjects();
-
-    const statements = protocol.getSQLStatements(models);
-    await db.query(statements);
-
-    const newModels = await getModels(packages, db);
-    expect(newModels).toHaveLength(1);
-    // @ts-expect-error This is defined!
-    expect(newModels[0]?.fields[1]?.type).toBe('json');
-  });
-
-  test('adding a unique field', async () => {
-    const definedModels: Array<Model> = [TestG];
-    const existingModels: Array<Model> = [TestN];
-
-    const db = await queryEphemeralDatabase(existingModels);
-    const packages = await getLocalPackages();
-    const models = await getModels(packages, db);
-
-    const modelDiff = await diffModels(definedModels, models);
-
-    const protocol = new Protocol(packages, modelDiff);
-    await protocol.convertToQueryObjects();
-
-    const statements = protocol.getSQLStatements(models);
-    await db.query(statements);
-
-    const newModels = await getModels(packages, db);
-    expect(newModels).toHaveLength(1);
-    // @ts-expect-error This is defined!
-    expect(newModels[0]?.fields[0]?.unique).toBe(true);
-  });
-
-  test('removing a unique field', async () => {
-    const definedModels: Array<Model> = [TestN];
-    const existingModels: Array<Model> = [TestG];
-
-    const db = await queryEphemeralDatabase(existingModels);
-    const packages = await getLocalPackages();
-    const models = await getModels(packages, db);
-
-    const modelDiff = await diffModels(definedModels, models);
-    const protocol = new Protocol(packages, modelDiff);
-    await protocol.convertToQueryObjects();
-
-    const statements = protocol.getSQLStatements(models);
-    await db.query(statements);
-
-    const newModels = await getModels(packages, db);
-    expect(newModels).toHaveLength(1);
-    // @ts-expect-error This is defined!
-    expect(newModels[0]?.fields[0]?.type).toBe('string');
-  });
-
-  test('removing field and adding new fields', async () => {
-    const definedModels: Array<Model> = [TestP];
-    const existingModels: Array<Model> = [TestO];
-
-    const db = await queryEphemeralDatabase(existingModels);
-    const packages = await getLocalPackages();
-    const models = await getModels(packages, db);
-
-    const modelDiff = await diffModels(definedModels, models);
-    console.log(modelDiff);
-    expect(modelDiff).toHaveLength(4);
-    const protocol = new Protocol(packages, modelDiff);
-    await protocol.convertToQueryObjects();
-
-    const statements = protocol.getSQLStatements(models);
-    await db.query(statements);
-
-    const newModels = await getModels(packages, db);
-    expect(newModels).toHaveLength(1);
-    // @ts-expect-error This is defined!
-    expect(newModels[0]?.fields[0]?.type).toBe('string');
-    // @ts-expect-error This is defined!
-    expect(newModels[0]?.fields[1]?.type).toBe('string');
-    // @ts-expect-error This is defined!
-    expect(newModels[0]?.fields[3]?.unique).toBe(true);
-  });
+  describe('error', () => {});
 });


### PR DESCRIPTION
This update enables alteration to fields of type `link` with `kind: 'many'`. Additionally, I've reorganized the tests for improved clarity and eliminated much of the redundant code. I also introduced helper functions to format SQL statements, making them more readable.