### PR TITLE
Reduce bundle size by removing `prettier` in favor for `dprint`

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,10 +35,8 @@
     "@ronin/engine": "0.0.27",
     "chalk-template": "1.1.0",
     "get-port": "7.1.0",
-    "i": "0.3.7",
     "ini": "5.0.0",
     "json5": "2.2.3",
-    "npm": "11.1.0",
     "open": "10.1.0",
     "ora": "8.1.1",
     "resolve-from": "5.0.0"

--- a/package.json
+++ b/package.json
@@ -28,16 +28,19 @@
   "author": "ronin",
   "license": "Apache-2.0",
   "dependencies": {
+    "@dprint/formatter": "0.4.1",
+    "@dprint/typescript": "0.93.3",
     "@iarna/toml": "2.2.5",
     "@inquirer/prompts": "7.2.3",
     "@ronin/engine": "0.0.27",
     "chalk-template": "1.1.0",
     "get-port": "7.1.0",
+    "i": "0.3.7",
     "ini": "5.0.0",
     "json5": "2.2.3",
+    "npm": "11.1.0",
     "open": "10.1.0",
     "ora": "8.1.1",
-    "prettier": "3.4.2",
     "resolve-from": "5.0.0"
   },
   "devDependencies": {

--- a/src/commands/diff.ts
+++ b/src/commands/diff.ts
@@ -71,7 +71,7 @@ export default async (
     const paddedNum = String(nextNum).padStart(4, '0');
     const protocol = new Protocol(packages, modelDiff);
     await protocol.convertToQueryObjects();
-    await protocol.save(`migration-${paddedNum}`);
+    protocol.save(`migration-${paddedNum}`);
 
     if (flags.sql) {
       const allModels = [...existingModels, ...definedModels];

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -3,9 +3,6 @@ import path from 'node:path';
 import { createFromBuffer } from '@dprint/formatter';
 import { getPath } from '@dprint/typescript';
 
-const buffer = fs.readFileSync(getPath());
-const formatter = createFromBuffer(buffer);
-
 /**
  * Detects code formatting configuration from common config files.
  *
@@ -76,6 +73,8 @@ export const detectFormatConfig = (): {
 
 export const formatCode = (code: string): string => {
   const config = detectFormatConfig();
+  const buffer = fs.readFileSync(getPath());
+  const formatter = createFromBuffer(buffer);
 
   const formated = formatter.formatText({
     filePath: 'asd.ts',

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -77,7 +77,7 @@ export const formatCode = (code: string): string => {
   const formatter = createFromBuffer(buffer);
 
   const formated = formatter.formatText({
-    filePath: 'asd.ts',
+    filePath: '.migration.ts',
     fileText: code,
     overrideConfig: {
       parser: 'typescript',

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,6 +1,10 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { format } from 'prettier';
+import { createFromBuffer } from '@dprint/formatter';
+import { getPath } from '@dprint/typescript';
+
+const buffer = fs.readFileSync(getPath());
+const formatter = createFromBuffer(buffer);
 
 /**
  * Detects code formatting configuration from common config files.
@@ -70,16 +74,22 @@ export const detectFormatConfig = (): {
   };
 };
 
-export const formatCode = (code: string): Promise<string> => {
+export const formatCode = (code: string): string => {
   const config = detectFormatConfig();
 
-  return format(code, {
-    parser: 'typescript',
-    useTabs: config.useTabs,
-    tabWidth: config.tabWidth,
-    singleQuote: config.singleQuote,
-    semi: config.semi,
+  const formated = formatter.formatText({
+    filePath: 'asd.ts',
+    fileText: code,
+    overrideConfig: {
+      parser: 'typescript',
+      useTabs: config.useTabs,
+      tabWidth: config.tabWidth,
+      singleQuote: config.singleQuote,
+      semi: config.semi,
+    },
   });
+
+  return formated;
 };
 
 /**

--- a/src/utils/protocol.ts
+++ b/src/utils/protocol.ts
@@ -133,14 +133,14 @@ export default () => [
    *
    * @returns The Protocol instance for chaining
    */
-  save = async (fileName: string): Promise<Protocol> => {
+  save = (fileName: string): Protocol => {
     const migrationContent = this.createMigrationProtocol();
     const directoryPath = path.resolve(this._protocolDir);
 
     fs.mkdirSync(directoryPath, { recursive: true });
     fs.writeFileSync(
       path.join(directoryPath, `${fileName}.ts`),
-      await formatCode(migrationContent),
+      formatCode(migrationContent),
     );
     return this;
   };

--- a/tests/utils/protocol.test.ts
+++ b/tests/utils/protocol.test.ts
@@ -39,11 +39,11 @@ describe('protocol', () => {
       writeFileSyncCalled = true;
       expect(path).toBe(`${process.cwd()}/schema/migrations/${fileName}.ts`);
       expect(data).toContain(
-        "create.model.to({ slug: 'my_model', pluralSlug: 'my_models' })",
+        'create.model.to({ slug: "my_model", pluralSlug: "my_models" })',
       );
     };
 
-    await protocol.save(fileName);
+    protocol.save(fileName);
     expect(writeFileSyncCalled).toBe(true);
 
     // Restore `fs.writeFileSync`


### PR DESCRIPTION
In [this pull request](https://github.com/ronin-co/cli/pull/8), I introduced code formatting for generated migration files using Prettier. However, Prettier added an extra `7.5 MB` to the bundle size, which significantly slowed down the CLI’s install process. As a result, I removed `prettier` and switched to `dprint`.