### PR TITLE
Migration now allows to add `required` fields

### DIFF
--- a/src/utils/field.ts
+++ b/src/utils/field.ts
@@ -1,3 +1,4 @@
+import type { MigrationOptions } from '@/src/utils/migration';
 import { RONIN_SCHEMA_TEMP_SUFFIX } from '@/src/utils/misc';
 import {
   createFieldQuery,
@@ -30,9 +31,7 @@ const handleRequiredField = async (
   modelSlug: string,
   field: ModelField,
   definedFields: Array<ModelField> | undefined,
-  options?: {
-    requiredDefault?: boolean | string;
-  },
+  options?: MigrationOptions,
 ): Promise<{
   defaultValue: string | boolean | undefined;
   definedFields: Array<ModelField> | undefined;
@@ -94,10 +93,7 @@ export const diffFields = async (
   modelSlug: string,
   indexes: Array<ModelIndex>,
   triggers: Array<ModelTrigger>,
-  options?: {
-    rename?: boolean;
-    requiredDefault?: boolean | string;
-  },
+  options?: MigrationOptions,
 ): Promise<Array<string>> => {
   const diff: Array<string> = [];
 
@@ -321,9 +317,7 @@ export const createFields = async (
   fields: Array<ModelField>,
   modelSlug: string,
   definedFields?: Array<ModelField>,
-  options?: {
-    requiredDefault?: boolean | string;
-  },
+  options?: MigrationOptions,
 ): Promise<Array<string>> => {
   const diff: Array<string> = [];
 

--- a/src/utils/field.ts
+++ b/src/utils/field.ts
@@ -20,7 +20,6 @@ import type { ModelField, ModelIndex, ModelTrigger } from '@ronin/compiler';
  * @param field - The field being made required.
  * @param definedFields - The complete list of fields defined for the model.
  * @param options - Optional configuration.
- * @param options.requiredDefault - A predefined default value to use instead of prompting.
  *
  * @returns Object containing:
  *   - defaultValue: The chosen default value for the required field.

--- a/src/utils/migration.ts
+++ b/src/utils/migration.ts
@@ -14,6 +14,14 @@ import { confirm } from '@inquirer/prompts';
 import type { Model } from '@ronin/compiler';
 
 /**
+ * Options for migration operations.
+ */
+export type MigrationOptions = {
+  rename?: boolean;
+  requiredDefault?: boolean | string;
+};
+
+/**
  * Fields to ignore.
  * There are several fields that are not relevant for the migration process.
  */
@@ -40,10 +48,7 @@ export const IGNORED_FIELDS = [
 export const diffModels = async (
   definedModels: Array<Model>,
   existingModels: Array<Model>,
-  options?: {
-    rename?: boolean;
-    requiredDefault?: boolean | string;
-  },
+  options?: MigrationOptions,
 ): Promise<Array<string>> => {
   const diff: Array<string> = [];
 
@@ -97,10 +102,7 @@ export const diffModels = async (
 const adjustModels = async (
   definedModels: Array<Model>,
   existingModels: Array<Model>,
-  options?: {
-    rename?: boolean;
-    requiredDefault?: boolean | string;
-  },
+  options?: MigrationOptions,
 ): Promise<Array<string>> => {
   const diff: Array<string> = [];
 

--- a/src/utils/migration.ts
+++ b/src/utils/migration.ts
@@ -40,7 +40,10 @@ export const IGNORED_FIELDS = [
 export const diffModels = async (
   definedModels: Array<Model>,
   existingModels: Array<Model>,
-  rename?: boolean,
+  options?: {
+    rename?: boolean;
+    requiredDefault?: boolean | string;
+  },
 ): Promise<Array<string>> => {
   const diff: Array<string> = [];
 
@@ -56,7 +59,7 @@ export const diffModels = async (
     // Ask if the user wants to rename the models
     for (const model of modelsToBeRenamed) {
       const confirmRename =
-        rename ||
+        options?.rename ||
         (process.env.NODE_ENV !== 'test' &&
           (await confirm({
             message: `Did you mean to rename model: ${model.from.slug} -> ${model.to.slug}`,
@@ -74,7 +77,7 @@ export const diffModels = async (
   diff.push(...adjustModelMetaQueries);
   diff.push(...dropModels(modelsToBeDropped));
   diff.push(...createModels(modelsToBeAdded));
-  diff.push(...(await adjustModels(definedModels, existingModels, rename)));
+  diff.push(...(await adjustModels(definedModels, existingModels, options)));
   diff.push(...recreateIndexes);
   diff.push(...recreateTriggers);
 
@@ -94,7 +97,10 @@ export const diffModels = async (
 const adjustModels = async (
   definedModels: Array<Model>,
   existingModels: Array<Model>,
-  rename?: boolean,
+  options?: {
+    rename?: boolean;
+    requiredDefault?: boolean | string;
+  },
 ): Promise<Array<string>> => {
   const diff: Array<string> = [];
 
@@ -109,7 +115,7 @@ const adjustModels = async (
           localModel.slug,
           localModel.indexes || [],
           localModel.triggers || [],
-          rename,
+          options,
         )),
       );
     }

--- a/tests/fixtures/index.ts
+++ b/tests/fixtures/index.ts
@@ -139,6 +139,14 @@ export const AccountNew = model({
   },
 }) as unknown as Model;
 
+export const AccountWithoutUnique = model({
+  slug: 'account',
+  fields: {
+    name: string(),
+    email: string({ required: true }),
+  },
+}) as unknown as Model;
+
 export const Account2 = model({
   slug: 'account',
   pluralSlug: 'accounts',
@@ -147,6 +155,15 @@ export const Account2 = model({
       required: true,
       unique: true,
     }),
+  },
+}) as unknown as Model;
+
+export const Account3 = model({
+  slug: 'account',
+  pluralSlug: 'accounts',
+  fields: {
+    name: string({ required: true, unique: true }),
+    email: string({ required: true, unique: true }),
   },
 }) as unknown as Model;
 
@@ -348,5 +365,13 @@ export const TestT = model({
   fields: {
     name: string(),
     email: string(),
+  },
+}) as unknown as Model;
+
+export const TestU = model({
+  slug: 'test',
+  fields: {
+    test: string(),
+    name: string({ required: true }),
   },
 }) as unknown as Model;

--- a/tests/fixtures/index.ts
+++ b/tests/fixtures/index.ts
@@ -123,6 +123,22 @@ export const ModelsA = [TestAccount, TestProfile, TestBlog];
 export const ModelsB = [TestAccount2, TestProfile2, TestBlog2, TestComments];
 /* export const ModelsC = [Account2, Profile]; */
 
+export const AccountWithBoolean = model({
+  slug: 'account',
+  fields: {
+    name: string(),
+    email: boolean(),
+  },
+}) as unknown as Model;
+
+export const AccountWithRequiredBoolean = model({
+  slug: 'account',
+  fields: {
+    name: string(),
+    email: boolean({ required: true }),
+  },
+}) as unknown as Model;
+
 export const Account = model({
   slug: 'account',
   pluralSlug: 'accounts',
@@ -144,6 +160,14 @@ export const AccountWithoutUnique = model({
   fields: {
     name: string(),
     email: string({ required: true }),
+  },
+}) as unknown as Model;
+
+export const AccountWithRequiredDefault = model({
+  slug: 'account',
+  fields: {
+    name: string(),
+    email: string({ required: true, defaultValue: 'RONIN_TEST_VALUE_REQUIRED_DEFAULT' }),
   },
 }) as unknown as Model;
 

--- a/tests/fixtures/utils.ts
+++ b/tests/fixtures/utils.ts
@@ -1,4 +1,4 @@
-import { diffModels } from '@/src/utils/migration';
+import { type MigrationOptions, diffModels } from '@/src/utils/migration';
 import { type LocalPackages, getLocalPackages } from '@/src/utils/misc';
 import { getModels } from '@/src/utils/model';
 import { Protocol } from '@/src/utils/protocol';
@@ -66,8 +66,7 @@ export const prefillDatabase = async (
  *
  * @param definedModels - The new/updated model definitions to migrate to.
  * @param existingModels - The current models in the database.
- * @param enableRename - Whether to enable model renaming during migration
- * (defaults to `false`).
+ * @param options - Optional configuration for migration operations.
  * @param insertStatements - The statements that should be executed to insert records into
  * the database.
  *
@@ -81,10 +80,7 @@ export const prefillDatabase = async (
 export const runMigration = async (
   definedModels: Array<Model>,
   existingModels: Array<Model>,
-  options?: {
-    rename?: boolean;
-    requiredDefault?: boolean | string;
-  },
+  options?: MigrationOptions,
   insertStatements: Array<Statement> = [],
 ): Promise<{
   db: Database;

--- a/tests/utils/apply.test.ts
+++ b/tests/utils/apply.test.ts
@@ -3,6 +3,9 @@ import {
   Account,
   Account3,
   AccountNew,
+  AccountWithBoolean,
+  AccountWithRequiredBoolean,
+  AccountWithRequiredDefault,
   AccountWithoutUnique,
   Profile,
   TestA,
@@ -433,6 +436,82 @@ describe('apply', () => {
             accounts: 1,
           });
           expect(rows[0].email).toBe('RONIN_TEST_VALUE');
+        });
+
+        test('required field with default value', async () => {
+          const insert = {
+            add: {
+              account: {
+                with: {
+                  name: 'Jacqueline',
+                },
+              },
+            },
+          };
+
+          const transaction = new Transaction([insert], {
+            models: [Account, AccountWithRequiredDefault],
+            inlineParams: true,
+          });
+
+          const { models, db } = await runMigration(
+            [AccountWithRequiredDefault],
+            [Account],
+            { rename: false, requiredDefault: 'RONIN_TEST_VALUE' },
+            transaction.statements.map((statement) => statement),
+          );
+
+          const rows = await getTableRows(db, Account3);
+
+          const rowCounts: Record<string, number> = {};
+          for (const model of models) {
+            if (model.pluralSlug) {
+              rowCounts[model.pluralSlug] = await getRowCount(db, model.pluralSlug);
+            }
+          }
+          expect(rowCounts).toEqual({
+            accounts: 1,
+          });
+          expect(rows[0].email).toBe('RONIN_TEST_VALUE_REQUIRED_DEFAULT');
+        });
+
+        test('required field with number', async () => {
+          const insert = {
+            add: {
+              account: {
+                with: {
+                  name: 'Jacqueline',
+                },
+              },
+            },
+          };
+
+          const transaction = new Transaction([insert], {
+            models: [AccountWithBoolean, AccountWithRequiredBoolean],
+            inlineParams: true,
+          });
+
+          const { models, db } = await runMigration(
+            [AccountWithRequiredBoolean],
+            [AccountWithBoolean],
+            { rename: false, requiredDefault: true },
+            transaction.statements.map((statement) => statement),
+          );
+
+          const rows = await getTableRows(db, Account3);
+
+          const rowCounts: Record<string, number> = {};
+          for (const model of models) {
+            if (model.pluralSlug) {
+              rowCounts[model.pluralSlug] = await getRowCount(db, model.pluralSlug);
+            }
+          }
+          expect(rowCounts).toEqual({
+            accounts: 1,
+          });
+          // TODO: This is not correct. This will be changed in another PR when we bump
+          // to the latest ronin version.
+          expect(rows[0].email).toBe('true');
         });
       });
 

--- a/tests/utils/apply.test.ts
+++ b/tests/utils/apply.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, test } from 'bun:test';
 import {
   Account,
+  Account3,
   AccountNew,
+  AccountWithoutUnique,
   Profile,
   TestA,
   TestB,
@@ -22,8 +24,12 @@ import {
   TestQ,
   TestR,
   TestT,
+  TestU,
 } from '@/fixtures/index';
-import { getRowCount, getSQLTables, runMigration } from '@/fixtures/utils';
+import { getRowCount, getSQLTables, getTableRows, runMigration } from '@/fixtures/utils';
+import { getLocalPackages } from '@/src/utils/misc';
+const packages = await getLocalPackages();
+const { Transaction } = packages.compiler;
 
 describe('apply', () => {
   describe('model', () => {
@@ -254,7 +260,9 @@ describe('apply', () => {
         });
 
         test('add unique field', async () => {
-          const { models, db } = await runMigration([TestG], [TestN]);
+          const { models, db } = await runMigration([TestG], [TestN], {
+            requiredDefault: 'RONIN_TEST_VALUE',
+          });
 
           const rowCounts: Record<string, number> = {};
           for (const model of models) {
@@ -331,7 +339,10 @@ describe('apply', () => {
         });
 
         test('rename', async () => {
-          const { models, db } = await runMigration([TestI], [TestH], true);
+          const { models, db } = await runMigration([TestI], [TestH], {
+            rename: true,
+            requiredDefault: 'RONIN_TEST_VALUE',
+          });
 
           const rowCounts: Record<string, number> = {};
           for (const model of models) {
@@ -343,6 +354,125 @@ describe('apply', () => {
           expect(rowCounts).toEqual({
             tests: 0,
           });
+        });
+      });
+    });
+
+    describe('with records', () => {
+      describe('create', () => {
+        test('required field & unqiue', async () => {
+          const insert = {
+            add: {
+              account: {
+                with: {
+                  name: 'Jacqueline',
+                },
+              },
+            },
+          };
+
+          const transaction = new Transaction([insert], {
+            models: [Account, Account3],
+            inlineParams: true,
+          });
+
+          const { models, db } = await runMigration(
+            [Account3],
+            [Account],
+            { rename: false, requiredDefault: 'RONIN_TEST_VALUE' },
+            transaction.statements.map((statement) => statement),
+          );
+
+          const rows = await getTableRows(db, Account3);
+
+          const rowCounts: Record<string, number> = {};
+          for (const model of models) {
+            if (model.pluralSlug) {
+              rowCounts[model.pluralSlug] = await getRowCount(db, model.pluralSlug);
+            }
+          }
+          expect(rowCounts).toEqual({
+            accounts: 1,
+          });
+
+          expect(rows[0].email).toBe('RONIN_TEST_VALUE');
+        });
+
+        test('required field', async () => {
+          const insert = {
+            add: {
+              account: {
+                with: {
+                  name: 'Jacqueline',
+                },
+              },
+            },
+          };
+
+          const transaction = new Transaction([insert], {
+            models: [Account, AccountWithoutUnique],
+            inlineParams: true,
+          });
+
+          const { models, db } = await runMigration(
+            [AccountWithoutUnique],
+            [Account],
+            { rename: false, requiredDefault: 'RONIN_TEST_VALUE' },
+            transaction.statements.map((statement) => statement),
+          );
+
+          const rows = await getTableRows(db, Account3);
+
+          const rowCounts: Record<string, number> = {};
+          for (const model of models) {
+            if (model.pluralSlug) {
+              rowCounts[model.pluralSlug] = await getRowCount(db, model.pluralSlug);
+            }
+          }
+          expect(rowCounts).toEqual({
+            accounts: 1,
+          });
+          expect(rows[0].email).toBe('RONIN_TEST_VALUE');
+        });
+      });
+
+      describe('update', () => {
+        test('required field', async () => {
+          const insert = {
+            add: {
+              test: {
+                with: {
+                  test: 'test',
+                },
+              },
+            },
+          };
+
+          const transaction = new Transaction([insert], {
+            models: [TestL, TestU],
+            inlineParams: true,
+          });
+
+          const { models, db } = await runMigration(
+            [TestU],
+            [TestL],
+            { rename: false, requiredDefault: 'RONIN_TEST_VALUE' },
+            transaction.statements.map((statement) => statement),
+          );
+
+          const rows = await getTableRows(db, TestU);
+
+          const rowCounts: Record<string, number> = {};
+          for (const model of models) {
+            if (model.pluralSlug) {
+              rowCounts[model.pluralSlug] = await getRowCount(db, model.pluralSlug);
+            }
+          }
+          expect(rowCounts).toEqual({
+            tests: 1,
+          });
+
+          expect(rows[0].name).toBe('RONIN_TEST_VALUE');
         });
       });
     });
@@ -412,11 +542,10 @@ describe('apply', () => {
 
       describe('update', () => {
         test('model name', async () => {
-          const { models, statements, db } = await runMigration(
-            [Account],
-            [AccountNew],
-            true,
-          );
+          const { models, statements, db } = await runMigration([Account], [AccountNew], {
+            rename: true,
+            requiredDefault: 'RONIN_TEST_VALUE',
+          });
 
           const rowCounts: Record<string, number> = {};
           for (const model of models) {
@@ -436,7 +565,7 @@ describe('apply', () => {
           const { models, db } = await runMigration(
             [AccountNew, Profile],
             [Account, Profile],
-            true,
+            { rename: true, requiredDefault: 'RONIN_TEST_VALUE' },
           );
 
           const rowCounts: Record<string, number> = {};
@@ -542,7 +671,7 @@ describe('apply', () => {
           const { models, db } = await runMigration(
             [TestE, TestB, Account],
             [TestD, TestA, AccountNew],
-            true,
+            { rename: true, requiredDefault: 'RONIN_TEST_VALUE' },
           );
 
           const rowCounts: Record<string, number> = {};
@@ -563,6 +692,7 @@ describe('apply', () => {
           const { models, db } = await runMigration(
             [TestB, TestE, Account],
             [TestA, TestD],
+            { rename: true, requiredDefault: 'RONIN_TEST_VALUE' },
           );
 
           const rowCounts: Record<string, number> = {};

--- a/tests/utils/field.test.ts
+++ b/tests/utils/field.test.ts
@@ -193,7 +193,9 @@ describe('fields', () => {
           target: 'profile',
         },
       ];
-      const diff = await diffFields(localFields, remoteFields, 'account', [], [], true);
+      const diff = await diffFields(localFields, remoteFields, 'account', [], [], {
+        rename: true,
+      });
       expect(diff).toHaveLength(5);
       expect(diff).toStrictEqual([
         "create.model({slug:'RONIN_TEMP_account',fields:[{type:'link', slug:'profile', target:'profile'}]})",
@@ -217,7 +219,9 @@ describe('fields', () => {
           slug: 'profile',
         },
       ];
-      const diff = await diffFields(localFields, remoteFields, 'account', [], [], true);
+      const diff = await diffFields(localFields, remoteFields, 'account', [], [], {
+        rename: true,
+      });
 
       expect(diff).toHaveLength(1);
       expect(diff).toStrictEqual([

--- a/tests/utils/migration.test.ts
+++ b/tests/utils/migration.test.ts
@@ -41,7 +41,7 @@ describe('migration', () => {
 
     test('generates migration steps when renaming model slug', async () => {
       // It is not recognized as a model.
-      const modelDiff = await diffModels([Account], [Account2], true);
+      const modelDiff = await diffModels([Account], [Account2], { rename: true });
 
       expect(modelDiff).toHaveLength(4);
       expect(modelDiff).toStrictEqual([
@@ -106,7 +106,9 @@ describe('migration', () => {
     });
 
     test('renames model when model is renamed', async () => {
-      const modelDiff = await diffModels([AccountNew, Profile], [Account, Profile], true);
+      const modelDiff = await diffModels([AccountNew, Profile], [Account, Profile], {
+        rename: true,
+      });
 
       expect(modelDiff).toHaveLength(1);
       expect(modelDiff).toStrictEqual([


### PR DESCRIPTION
Previously, developers couldn't add required fields without default values in SQLite because adding a column to a table with existing rows would result in empty values, conflicting with the required property. Now, developers are prompted to set a temporary default value.