### PR TITLE
Added `--choose` flag to select specific migration file

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -197,7 +197,7 @@
 
     "@types/ini": ["@types/ini@4.1.1", "", {}, "sha512-MIyNUZipBTbyUNnhvuXJTY7B6qNI78meck9Jbv3wk0OgNwRyOOVEKDutAkOs1snB/tx0FafyR6/SN4Ps0hZPeg=="],
 
-    "@types/node": ["@types/node@22.13.4", "", { "dependencies": { "undici-types": "~6.20.0" } }, "sha512-ywP2X0DYtX3y08eFVx5fNIw7/uIv8hYUKgXoK8oayJlLnKcRfEYCxWMVE1XagUdVtCJlZT1AU4LXEABW+L1Peg=="],
+    "@types/node": ["@types/node@22.13.5", "", { "dependencies": { "undici-types": "~6.20.0" } }, "sha512-+lTU0PxZXn0Dr1NBtC7Y8cR21AJr87dLLU953CWA6pMxxv/UDc7jYAY90upcrie1nRcD6XNG5HOYEDtgW5TxAg=="],
 
     "@types/ws": ["@types/ws@8.5.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-bd/YFLW+URhBzMXurx7lWByOu+xzU9+kb3RboOteXYDfW+tr+JZa99OyNmPINEGB/ahzKrEuc8rcv4gnpJmxTw=="],
 
@@ -389,7 +389,7 @@
 
     "tinyexec": ["tinyexec@0.3.2", "", {}, "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="],
 
-    "tinyglobby": ["tinyglobby@0.2.11", "", { "dependencies": { "fdir": "^6.4.3", "picomatch": "^4.0.2" } }, "sha512-32TmKeeKUahv0Go8WmQgiEp9Y21NuxjwjqiRC1nrUB51YacfSwuB44xgXD+HdIppmMRgjQNPdrHyA6vIybYZ+g=="],
+    "tinyglobby": ["tinyglobby@0.2.12", "", { "dependencies": { "fdir": "^6.4.3", "picomatch": "^4.0.2" } }, "sha512-qkf4trmKSIiMTs/E63cxH+ojC2unam7rJ0WrauAzpT3ECNTxGRMlaXxVbfxMUC/w0LaYk6jQ4y/nGR9uBO3tww=="],
 
     "tmp": ["tmp@0.0.33", "", { "dependencies": { "os-tmpdir": "~1.0.2" } }, "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw=="],
 

--- a/src/commands/apply.ts
+++ b/src/commands/apply.ts
@@ -36,19 +36,20 @@ export default async (
 
     // Get all filenames of migrations in the migrations directory.
     const migrations = fs.readdirSync(MIGRATIONS_PATH);
+    // Sort migrations in reverse lexical order
+    const sortedMigrations = migrations.sort((a, b) => b.localeCompare(a));
 
     const migrationPrompt =
       migrationFilePath ??
-      (await select({
-        message: 'Which migration do you want to apply?',
-        choices: migrations
-          // Sort in reverse lexical order
-          .sort((a, b) => b.localeCompare(a))
-          .map((migration) => ({
-            name: migration,
-            value: path.join(MIGRATIONS_PATH, migration),
-          })),
-      }));
+      (flags.choose
+        ? await select({
+            message: 'Which migration do you want to apply?',
+            choices: sortedMigrations.map((migration) => ({
+              name: migration,
+              value: path.join(MIGRATIONS_PATH, migration),
+            })),
+          })
+        : path.join(MIGRATIONS_PATH, sortedMigrations[0]));
 
     const protocol = await new Protocol(packages).load(migrationPrompt);
     const statements = protocol.getSQLStatements(

--- a/src/utils/info.ts
+++ b/src/utils/info.ts
@@ -30,6 +30,7 @@ export const printHelp = (): Promise<void> => {
       -h, --help                          Shows this help message
       -v, --version                       Shows the version of the CLI that is currently installed
       -d, --debug                         Shows additional debugging information
+      -c, --choose                        Choose the migration to apply
   `;
   console.log(text);
   process.exit(0);

--- a/src/utils/migration.ts
+++ b/src/utils/migration.ts
@@ -423,6 +423,7 @@ export const MIGRATION_FLAGS = {
   sql: { type: 'boolean', short: 's', default: false },
   local: { type: 'boolean', short: 'l', default: false },
   apply: { type: 'boolean', short: 'a', default: false },
+  choose: { type: 'boolean', short: 'c', default: false },
 } satisfies NonNullable<Parameters<typeof parseArgs>[0]>['options'];
 
 /**


### PR DESCRIPTION
The `ronin apply` command has been updated to automatically apply the latest migration by default. Previously, the user was prompted to select which migration to apply each time. If you now wish to apply a specific migration, you can use the -`-choose` flag, which will allow you to select a particular migration to apply.