### PR TITLE
Correctly name models after temporary model creation

### DIFF
--- a/src/utils/migration.ts
+++ b/src/utils/migration.ts
@@ -10,7 +10,6 @@ import {
   createIndexQuery,
   createModelQuery,
   createTempModelQuery,
-  createTempModelQuery,
   createTriggerQuery,
   dropIndexQuery,
   dropModelQuery,

--- a/src/utils/queries.ts
+++ b/src/utils/queries.ts
@@ -119,6 +119,8 @@ export const createTempModelQuery = (
   options?: {
     customQueries?: Array<string>;
     includeFields?: Array<ModelField>;
+    name?: string;
+    pluralName?: string;
   },
 ): Array<string> => {
   const { slug, fields, indexes: _indexes, triggers, ...rest } = model;
@@ -146,7 +148,9 @@ export const createTempModelQuery = (
   queries.push(dropModelQuery(slug));
 
   // Rename the copied model to the original model
-  queries.push(`alter.model("${tempModelSlug}").to({slug: "${slug}"})`);
+  queries.push(
+    `alter.model("${tempModelSlug}").to({slug: "${slug}", name: "${options?.name}", pluralName: "${options?.pluralName}"})`,
+  );
 
   for (const [key, value] of Object.entries(triggers || {})) {
     queries.push(createTriggerQuery(slug, { ...value, slug: key }));

--- a/tests/utils/apply.test.ts
+++ b/tests/utils/apply.test.ts
@@ -31,6 +31,8 @@ import {
 } from '@/fixtures/index';
 import { getRowCount, getSQLTables, getTableRows, runMigration } from '@/fixtures/utils';
 import { getLocalPackages } from '@/src/utils/misc';
+import type { Model } from 'ronin/schema';
+import { model, string } from 'ronin/schema';
 const packages = await getLocalPackages();
 const { Transaction } = packages.compiler;
 

--- a/tests/utils/apply.test.ts
+++ b/tests/utils/apply.test.ts
@@ -31,8 +31,6 @@ import {
 } from '@/fixtures/index';
 import { getRowCount, getSQLTables, getTableRows, runMigration } from '@/fixtures/utils';
 import { getLocalPackages } from '@/src/utils/misc';
-import type { Model } from '@ronin/syntax/schema';
-import { model, string } from 'ronin/schema';
 const packages = await getLocalPackages();
 const { Transaction } = packages.compiler;
 
@@ -52,6 +50,8 @@ describe('apply', () => {
 
           expect(statements).toHaveLength(4);
           expect(models).toHaveLength(1);
+          expect(models[0].name).toBe('Test');
+          expect(models[0].pluralName).toBe('Tests');
           expect(models[0].slug).toBe('test');
           expect(rowCounts).toEqual({
             tests: 0,
@@ -69,6 +69,8 @@ describe('apply', () => {
           }
           expect(statements).toHaveLength(4);
           expect(models).toHaveLength(1);
+          expect(models[0].name).toBe('Test');
+          expect(models[0].pluralName).toBe('Tests');
           expect(models[0].slug).toBe('test');
           expect(rowCounts).toEqual({
             tests: 0,
@@ -86,6 +88,8 @@ describe('apply', () => {
           }
           expect(models).toHaveLength(2);
           expect(models[0].triggers).toBeDefined();
+          expect(models[0].name).toBe('ThisIsACoolModel');
+          expect(models[0].pluralName).toBe('Tests');
           expect(rowCounts).toEqual({
             tests: 0,
             comments: 0,
@@ -103,6 +107,10 @@ describe('apply', () => {
           }
           expect(statements.length).toEqual(4);
           expect(models).toHaveLength(2);
+          expect(models[0].name).toBe('Account');
+          expect(models[0].pluralName).toBe('Accounts');
+          expect(models[1].name).toBe('Profile');
+          expect(models[1].pluralName).toBe('Profiles');
           expect(rowCounts).toEqual({
             accounts: 0,
             profiles: 0,
@@ -201,7 +209,7 @@ describe('apply', () => {
           }
 
           expect(models).toHaveLength(1);
-          expect(models[0].name).toBe('ThisIsACoolModel');
+          expect(models[0].name).toBe('Test');
           expect(rowCounts).toEqual({
             tests: 0,
           });
@@ -292,6 +300,8 @@ describe('apply', () => {
           const rows = await getTableRows(db, models[0]);
 
           expect(models[0].slug).toBe('test');
+          expect(models[0].name).toBe('Test');
+          expect(models[0].pluralName).toBe('Tests');
           expect(rows[0].id).toContain('corny_');
           expect(rows[1].id).toContain('test_');
         });

--- a/tests/utils/field.test.ts
+++ b/tests/utils/field.test.ts
@@ -168,13 +168,16 @@ describe('fields', () => {
           unique: false,
         },
       ];
-      const diff = await diffFields(localFields, remoteFields, 'account', [], []);
+      const diff = await diffFields(localFields, remoteFields, 'account', [], [], {
+        name: 'Account',
+        pluralName: 'Accounts',
+      });
       expect(diff).toHaveLength(4);
       expect(diff).toStrictEqual([
         'create.model({"slug":"RONIN_TEMP_account","fields":{"id":{"type":"number","unique":true}}})',
         'add.RONIN_TEMP_account.with(() => get.account())',
         'drop.model("account")',
-        'alter.model("RONIN_TEMP_account").to({slug: "account"})',
+        'alter.model("RONIN_TEMP_account").to({slug: "account", name: "Account", pluralName: "Accounts"})',
       ]);
     });
 
@@ -194,6 +197,8 @@ describe('fields', () => {
         },
       ];
       const diff = await diffFields(localFields, remoteFields, 'account', [], [], {
+        name: 'Account',
+        pluralName: 'Accounts',
         rename: true,
       });
       expect(diff).toHaveLength(5);
@@ -202,7 +207,7 @@ describe('fields', () => {
         'add.RONIN_TEMP_account.with(() => get.account())',
         'alter.model("RONIN_TEMP_account").alter.field("profile").to({slug: "newProfile"})',
         'drop.model("account")',
-        'alter.model("RONIN_TEMP_account").to({slug: "account"})',
+        'alter.model("RONIN_TEMP_account").to({slug: "account", name: "Account", pluralName: "Accounts"})',
       ]);
     });
 

--- a/tests/utils/migration.test.ts
+++ b/tests/utils/migration.test.ts
@@ -39,14 +39,19 @@ describe('migration', () => {
 
     test('generates migration steps when renaming model slug', async () => {
       // It is not recognized as a model.
-      const modelDiff = await diffModels([Account], [Account2], { rename: true });
+      const modelDiff = await diffModels([Account], [Account2], {
+        rename: true,
+        name: 'Account',
+        pluralName: 'Accounts',
+      });
 
       expect(modelDiff).toHaveLength(4);
       expect(modelDiff).toStrictEqual([
         'create.model({"slug":"RONIN_TEMP_account","fields":{"name":{"type":"string"}}})',
         'add.RONIN_TEMP_account.with(() => get.account())',
         'drop.model("account")',
-        'alter.model("RONIN_TEMP_account").to({slug: "account"})',
+        // The names are undefined because the existing model never got run through the compiler.
+        'alter.model("RONIN_TEMP_account").to({slug: "account", name: "undefined", pluralName: "undefined"})',
       ]);
     });
 
@@ -76,33 +81,42 @@ describe('migration', () => {
         'create.model({"slug":"RONIN_TEMP_account","fields":{"name":{"required":true,"unique":true,"type":"string"}}})',
         'add.RONIN_TEMP_account.with(() => get.account())',
         'drop.model("account")',
-        'alter.model("RONIN_TEMP_account").to({slug: "account"})',
+        // The names are undefined because the existing model never got run through the compiler.
+        'alter.model("RONIN_TEMP_account").to({slug: "account", name: "undefined", pluralName: "undefined"})',
       ]);
     });
 
     test('generates migration steps when meta model properties change', async () => {
       // It is not recognized as a model.
-      const modelDiff = await diffModels([TestC], [TestA]);
+      const modelDiff = await diffModels([TestC], [TestA], {
+        name: 'ThisIsACoolModel',
+        pluralName: 'ThisIsACoolModels',
+      });
 
       expect(modelDiff).toHaveLength(4);
       expect(modelDiff).toStrictEqual([
         'create.model({"slug":"RONIN_TEMP_test","fields":{"age":{"required":true,"unique":true,"type":"string"},"active":{"type":"boolean"}},"name":"ThisIsACoolModel","idPrefix":"TICM"})',
         'add.RONIN_TEMP_test.with(() => get.test())',
         'drop.model("test")',
-        'alter.model("RONIN_TEMP_test").to({slug: "test"})',
+        // The names are undefined because the existing model never got run through the compiler.
+        'alter.model("RONIN_TEMP_test").to({slug: "test", name: "undefined", pluralName: "undefined"})',
       ]);
     });
 
     test('generates migration steps when field definitions differ', async () => {
       // It is not recognized as a model.
-      const modelDiff = await diffModels([Account], [Account2]);
+      const modelDiff = await diffModels([Account], [Account2], {
+        name: 'Account',
+        pluralName: 'Accounts',
+      });
 
       expect(modelDiff).toHaveLength(4);
       expect(modelDiff).toStrictEqual([
         'create.model({"slug":"RONIN_TEMP_account","fields":{"name":{"type":"string"}}})',
         'add.RONIN_TEMP_account.with(() => get.account())',
         'drop.model("account")',
-        'alter.model("RONIN_TEMP_account").to({slug: "account"})',
+        // The names are undefined because the existing model never got run through the compiler.
+        'alter.model("RONIN_TEMP_account").to({slug: "account", name: "undefined", pluralName: "undefined"})',
       ]);
     });
 
@@ -379,11 +393,13 @@ describe('migration', () => {
         {
           slug: 'test1',
           name: 'Old Name 1',
+          pluralName: 'Old Plural Name 1',
           idPrefix: 'OLD1',
         },
         {
           slug: 'test2',
           name: 'Test Model 2', // Same name
+          pluralName: 'Old Plural Name 2',
           idPrefix: 'OLD2',
         },
       ];
@@ -395,11 +411,11 @@ describe('migration', () => {
         'create.model({"slug":"RONIN_TEMP_test1","fields":{},"name":"Test Model 1","idPrefix":"TM1"})',
         'add.RONIN_TEMP_test1.with(() => get.test1())',
         'drop.model("test1")',
-        'alter.model("RONIN_TEMP_test1").to({slug: "test1"})',
+        'alter.model("RONIN_TEMP_test1").to({slug: "test1", name: "Old Name 1", pluralName: "Old Plural Name 1"})',
         'create.model({"slug":"RONIN_TEMP_test2","fields":{},"name":"Test Model 2","idPrefix":"TM2"})',
         'add.RONIN_TEMP_test2.with(() => get.test2())',
         'drop.model("test2")',
-        'alter.model("RONIN_TEMP_test2").to({slug: "test2"})',
+        'alter.model("RONIN_TEMP_test2").to({slug: "test2", name: "Test Model 2", pluralName: "Old Plural Name 2"})',
       ]);
     });
 

--- a/tests/utils/queries.test.ts
+++ b/tests/utils/queries.test.ts
@@ -107,13 +107,16 @@ describe('queries', () => {
       },
     };
 
-    // @ts-expect-error TODO: Fix this type.
-    const result = createTempModelQuery({ slug: 'user', fields });
+    const result = createTempModelQuery(
+      // @ts-expect-error TODO: Fix this type.
+      { slug: 'user', fields },
+      { name: 'User', pluralName: 'Users' },
+    );
     expect(result).toEqual([
       'create.model({"slug":"RONIN_TEMP_user","fields":{"username":{"type":"string","name":"Username","unique":true,"required":true}}})',
       'add.RONIN_TEMP_user.with(() => get.user())',
       'drop.model("user")',
-      'alter.model("RONIN_TEMP_user").to({slug: "user"})',
+      'alter.model("RONIN_TEMP_user").to({slug: "user", name: "User", pluralName: "Users"})',
     ]);
   });
 
@@ -129,14 +132,17 @@ describe('queries', () => {
     };
 
     const customQueries: Array<string> = ['get.model("user")'];
-    // @ts-expect-error TODO: Fix this type.
-    const result = createTempModelQuery({ slug: 'user', fields }, { customQueries });
+    const result = createTempModelQuery(
+      // @ts-expect-error TODO: Fix this type.
+      { slug: 'user', fields },
+      { customQueries, name: 'User', pluralName: 'Users' },
+    );
     expect(result).toEqual([
       'create.model({"slug":"RONIN_TEMP_user","fields":{"username":{"slug":"username","type":"string","name":"Username","unique":true,"required":true}}})',
       'add.RONIN_TEMP_user.with(() => get.user())',
       ...customQueries,
       'drop.model("user")',
-      'alter.model("RONIN_TEMP_user").to({slug: "user"})',
+      'alter.model("RONIN_TEMP_user").to({slug: "user", name: "User", pluralName: "Users"})',
     ]);
   });
 
@@ -158,13 +164,19 @@ describe('queries', () => {
       },
     };
 
-    // @ts-expect-error Todo fix this type.
-    const result = createTempModelQuery({ slug: 'user', fields, triggers });
+    const result = createTempModelQuery(
+      // @ts-expect-error Todo fix this type.
+      { slug: 'user', fields, triggers },
+      {
+        name: 'User',
+        pluralName: 'Users',
+      },
+    );
     expect(result).toEqual([
       'create.model({"slug":"RONIN_TEMP_user","fields":{"username":{"type":"string","name":"Username","unique":true,"required":true}}})',
       'add.RONIN_TEMP_user.with(() => get.user())',
       'drop.model("user")',
-      'alter.model("RONIN_TEMP_user").to({slug: "user"})',
+      'alter.model("RONIN_TEMP_user").to({slug: "user", name: "User", pluralName: "Users"})',
       'alter.model("user").create.trigger({"action":"INSERT","when":"BEFORE","effects":[],"slug":"test"})',
     ]);
   });


### PR DESCRIPTION
In https://github.com/ronin-co/compiler/pull/144, we changed the behavior so that `name` and `pluralName` are no longer automatically regenerated when altering a model’s slug. Instead, we now set these values directly in the CLI. This PR resolves the resulting issue by ensuring that models receive the correct names after creating temporary tables.