### PR TITLE
Only import necessary queries

### DIFF
--- a/src/utils/protocol.ts
+++ b/src/utils/protocol.ts
@@ -89,7 +89,7 @@ export class Protocol {
       'count',
     ];
     const usedQueryTypes = queryTypes.filter((type) =>
-      this._roninQueries.some((query) => query.includes(`${type}.`)),
+      this._roninQueries.some((query) => query.startsWith(`${type}.`)),
     );
 
     // Only import the query types that are actually used

--- a/src/utils/protocol.ts
+++ b/src/utils/protocol.ts
@@ -77,7 +77,29 @@ export class Protocol {
    * @private
    */
   private createMigrationProtocol = (): string => {
-    return `import { add, alter, create, drop, get, set } from 'ronin';
+    // Analyze which query types are actually used in the queries
+    const queryTypes = [
+      'add',
+      'alter',
+      'create',
+      'drop',
+      'get',
+      'set',
+      'remove',
+      'count',
+    ];
+    const usedQueryTypes = queryTypes.filter((type) =>
+      this._roninQueries.some((query) => query.includes(`${type}.`)),
+    );
+
+    // Only import the query types that are actually used
+    const imports =
+      usedQueryTypes.length > 0
+        ? `import { ${usedQueryTypes.join(', ')} } from 'ronin';`
+        : '';
+
+    return `${imports}
+    
 export default () => [
   ${this._roninQueries.map((query) => ` ${query}`).join(',\n')}
 ];`;

--- a/tests/utils/protocol.test.ts
+++ b/tests/utils/protocol.test.ts
@@ -124,13 +124,13 @@ describe('protocol', () => {
     ];
     const createProtocol = new Protocol(packages, createQueries);
 
-    // Mock fs.mkdirSync and fs.writeFileSync
+    // Mock `fs.mkdirSync` and `fs.writeFileSync`
     spyOn(fs, 'mkdirSync').mockImplementation(() => {});
     const writeFileSpy = spyOn(fs, 'writeFileSync').mockImplementation(() => {});
 
     createProtocol.save(fileName);
 
-    // Check the content of the first call to writeFileSync
+    // Check the content of the first call to `fs.writeFileSync`
     const createFileContent = writeFileSpy.mock.calls[0][1] as string;
     expect(createFileContent).toContain('import { create } from "ronin";');
     expect(createFileContent).not.toContain('get');
@@ -153,7 +153,7 @@ describe('protocol', () => {
 
     mixedProtocol.save(fileName);
 
-    // Check the content of the first call to writeFileSync
+    // Check the content of the first call to `fs.writeFileSync`
     const mixedFileContent = mixedWriteFileSpy.mock.calls[0][1] as string;
     expect(mixedFileContent).toContain('import { create, get, set } from "ronin";');
     expect(mixedFileContent).not.toContain('alter');

--- a/tests/utils/protocol.test.ts
+++ b/tests/utils/protocol.test.ts
@@ -155,9 +155,7 @@ describe('protocol', () => {
 
     // Check the content of the first call to writeFileSync
     const mixedFileContent = mixedWriteFileSpy.mock.calls[0][1] as string;
-    expect(mixedFileContent).toContain(
-      'import { count, create, get, set } from "ronin";',
-    );
+    expect(mixedFileContent).toContain('import { create, get, set } from "ronin";');
     expect(mixedFileContent).not.toContain('alter');
     expect(mixedFileContent).not.toContain('drop');
   });


### PR DESCRIPTION
In most cases, not every query is needed during a migration, so we now import only the necessary queries.