### PR TITLE
Detect models with forbidden model slugs

### DIFF
--- a/src/utils/misc.ts
+++ b/src/utils/misc.ts
@@ -11,6 +11,9 @@ import type * as CompilerPackage from '@ronin/compiler';
 import type * as SyntaxPackage from '@ronin/syntax/queries';
 import resolveFrom from 'resolve-from';
 
+/** List of now allowed model slugs. */
+const NOT_ALLOWED_MODEL_SLUGS = ['', 'model'];
+
 /** Represents a data item for logging */
 interface DataItem {
   slug?: string;
@@ -231,6 +234,15 @@ export const getModelDefinitions = async (customPath?: string): Promise<Array<Mo
       );
       process.exit(1);
     }
+  }
+
+  const notAllowedModel = sortedModels.find((model) =>
+    NOT_ALLOWED_MODEL_SLUGS.includes(model.slug),
+  );
+
+  if (notAllowedModel) {
+    spinner.fail(`The root model cannot have a slug of "${notAllowedModel.slug}".`);
+    process.exit(1);
   }
 
   return sortedModels;

--- a/src/utils/misc.ts
+++ b/src/utils/misc.ts
@@ -11,7 +11,7 @@ import type * as CompilerPackage from '@ronin/compiler';
 import type * as SyntaxPackage from '@ronin/syntax/queries';
 import resolveFrom from 'resolve-from';
 
-/** List of now allowed model slugs. */
+/** List of not allowed model slugs. */
 const NOT_ALLOWED_MODEL_SLUGS = ['', 'model'];
 
 /** Represents a data item for logging */

--- a/src/utils/misc.ts
+++ b/src/utils/misc.ts
@@ -236,12 +236,10 @@ export const getModelDefinitions = async (customPath?: string): Promise<Array<Mo
     }
   }
 
-  const notAllowedModel = sortedModels.find((model) =>
-    NOT_ALLOWED_MODEL_SLUGS.includes(model.slug),
-  );
+  const notAllowedModel = sortedModels.find((model) => model.slug === '');
 
   if (notAllowedModel) {
-    spinner.fail(`The root model cannot have a slug of "${notAllowedModel.slug}".`);
+    spinner.fail('The `slug` attribute of models must not be empty.');
     process.exit(1);
   }
 

--- a/src/utils/misc.ts
+++ b/src/utils/misc.ts
@@ -11,9 +11,6 @@ import type * as CompilerPackage from '@ronin/compiler';
 import type * as SyntaxPackage from '@ronin/syntax/queries';
 import resolveFrom from 'resolve-from';
 
-/** List of not allowed model slugs. */
-const NOT_ALLOWED_MODEL_SLUGS = ['', 'model'];
-
 /** Represents a data item for logging */
 interface DataItem {
   slug?: string;

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -35,7 +35,9 @@ describe('CLI Integration Tests', () => {
   });
 
   test('should show help text when run without arguments', async () => {
-    const { stdout, exitCode } = await $`bun ${CLI_PATH}`.nothrow().quiet();
+    const { stdout, exitCode } = await $`RONIN_TOKEN=test bun ${CLI_PATH}`
+      .nothrow()
+      .quiet();
 
     expect(exitCode).toBe(0);
     expect(stdout.toString()).toContain('Data at the edge');
@@ -49,7 +51,9 @@ describe('CLI Integration Tests', () => {
   });
 
   test('should fail init command without space handle', async () => {
-    const { stderr, exitCode } = await $`bun ${CLI_PATH} init`.nothrow().quiet();
+    const { stderr, exitCode } = await $`RONIN_TOKEN=test bun ${CLI_PATH} init`
+      .nothrow()
+      .quiet();
 
     expect(exitCode).toBe(1);
     expect(stderr.toString()).toContain('Please provide a space handle like this:');
@@ -65,12 +69,13 @@ describe('CLI Integration Tests', () => {
 
     await fs.promises.writeFile(path.join(tempDir, '.gitignore'), 'node_modules\n');
 
-    // This test might need to mock HTTP calls or use a test token
-    const { stderr, exitCode } = await $`bun ${CLI_PATH} init test-space`
+    const { stderr, exitCode } = await $`RONIN_TOKEN=test bun ${CLI_PATH} init test-space`
       .nothrow()
       .quiet();
 
     expect(exitCode).toBe(1);
-    expect(stderr.toString()).toContain('You are not a member of the "test-space" space');
+    expect(stderr.toString()).toContain(
+      'You are not a member of the "test-space" space or the space doesn\'t exist.',
+    );
   });
 });

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -35,9 +35,6 @@ describe('CLI Integration Tests', () => {
   });
 
   test('should show help text when run without arguments', async () => {
-    // Set environment variables for non-interactive testing
-    process.env.RONIN_TOKEN = 'test-token';
-
     const { stdout, exitCode } = await $`bun ${CLI_PATH}`.nothrow().quiet();
 
     expect(exitCode).toBe(0);
@@ -45,9 +42,6 @@ describe('CLI Integration Tests', () => {
   });
 
   test('should show version when run with --version flag', async () => {
-    // Set environment variables for non-interactive testing
-    process.env.RONIN_TOKEN = 'test-token';
-
     const { stdout, exitCode } = await $`bun ${CLI_PATH} --version`.nothrow().quiet();
 
     expect(exitCode).toBe(0);
@@ -55,16 +49,14 @@ describe('CLI Integration Tests', () => {
   });
 
   test('should fail init command without space handle', async () => {
-    const { stderr, exitCode } = await $`RONIN_TOKEN=test-token bun ${CLI_PATH} init`
-      .nothrow()
-      .quiet();
+    const { stderr, exitCode } = await $`bun ${CLI_PATH} init`.nothrow().quiet();
 
     expect(exitCode).toBe(1);
     expect(stderr.toString()).toContain('Please provide a space handle like this:');
     expect(stderr.toString()).toContain('$ ronin init my-space');
   });
 
-  test('should initialize a project', async () => {
+  test('should fail to initialize a project', async () => {
     // Mock necessary files for a successful init
     await fs.promises.writeFile(
       path.join(tempDir, 'tsconfig.json'),
@@ -74,8 +66,9 @@ describe('CLI Integration Tests', () => {
     await fs.promises.writeFile(path.join(tempDir, '.gitignore'), 'node_modules\n');
 
     // This test might need to mock HTTP calls or use a test token
-    const { stderr, exitCode } =
-      await $`RONIN_TOKEN=test-token bun ${CLI_PATH} init test-space`.nothrow().quiet();
+    const { stderr, exitCode } = await $`bun ${CLI_PATH} init test-space`
+      .nothrow()
+      .quiet();
 
     expect(exitCode).toBe(1);
     expect(stderr.toString()).toContain('You are not a member of the "test-space" space');

--- a/tests/utils/misc.test.ts
+++ b/tests/utils/misc.test.ts
@@ -168,12 +168,8 @@ describe('misc', () => {
         expect(error.message).toBe('process.exit called');
       }
 
-      expect(ora.mock.calls).toEqual(
-        expect.arrayContaining([
-          expect.arrayContaining([
-            expect.stringContaining('The root model cannot have a slug of'),
-          ]),
-        ]),
+      expect(ora).toHaveBeenCalledWith(
+        expect.stringContaining('The root model cannot have a slug of'),
       );
     });
 

--- a/tests/utils/misc.test.ts
+++ b/tests/utils/misc.test.ts
@@ -150,8 +150,8 @@ describe('misc', () => {
 
       mock.module(MODEL_IN_CODE_PATH, () => {
         return {
-          ROOT_MODEL: {
-            slug: 'model',
+          Account: {
+            slug: '',
           },
         };
       });
@@ -169,7 +169,7 @@ describe('misc', () => {
       }
 
       expect(ora).toHaveBeenCalledWith(
-        expect.stringContaining('The root model cannot have a slug of'),
+        expect.stringContaining('The `slug` attribute of models must not be empty.'),
       );
     });
 


### PR DESCRIPTION
This update enhances the CLI to automatically detect when a user defines a model with a forbidden slug. If a forbidden slug is detected, the CLI will inform the developer to make the necessary adjustments.