### PR TITLE
Make tests work for all bun versions

### DIFF
--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -477,7 +477,11 @@ describe('CLI', () => {
           stderrSpy.mock.calls.some(
             (call) =>
               typeof call[0] === 'string' &&
-              call[0].includes("Cannot find module 'schema/index.ts'"),
+              // Bun's error message format changed between versions - it can use either single
+              // or double quotes around module paths in "Cannot find module" errors, so we need
+              // to check for both variants to make our tests resilient to Bun version changes.
+              (call[0].includes("Cannot find module 'schema/index.ts'") ||
+                call[0].includes('Cannot find module "schema/index.ts"')),
           ),
         ).toBe(true);
       });


### PR DESCRIPTION
The error message format in Bun has been updated between versions, which is causing the tests to fail for some users. 