### PR TITLE
Create ronin project structure on init

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -6,6 +6,7 @@ import json5 from 'json5';
 import ora from 'ora';
 
 import { exists } from '@/src/utils/file';
+import { MIGRATIONS_PATH, MODEL_IN_CODE_PATH } from '@/src/utils/misc';
 
 export const exec = util.promisify(childProcess.exec);
 
@@ -25,6 +26,15 @@ export default async (positionals: Array<string>): Promise<void> => {
     );
     process.exit(1);
   }
+
+  // Create ronin directories.
+  await fs.mkdir(MIGRATIONS_PATH, { recursive: true });
+
+  // Create a `schema/index.ts` file.
+  await fs.writeFile(
+    MODEL_IN_CODE_PATH,
+    '// This file is the starting point to define your models in code.\n',
+  );
 
   const packageManager = (await exists('bun.lockb')) ? 'bun' : 'npm';
   const packageManagerName = packageManager === 'bun' ? 'Bun' : 'npm';

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -6,7 +6,8 @@ import json5 from 'json5';
 import ora from 'ora';
 
 import { exists } from '@/src/utils/file';
-import { MIGRATIONS_PATH, MODEL_IN_CODE_PATH } from '@/src/utils/misc';
+import { MIGRATIONS_PATH, MODEL_IN_CODE_PATH, getLocalPackages } from '@/src/utils/misc';
+import { getModels } from '@/src/utils/model';
 
 export const exec = util.promisify(childProcess.exec);
 
@@ -27,15 +28,6 @@ export default async (positionals: Array<string>): Promise<void> => {
     process.exit(1);
   }
 
-  // Create ronin directories.
-  await fs.mkdir(MIGRATIONS_PATH, { recursive: true });
-
-  // Create a `schema/index.ts` file.
-  await fs.writeFile(
-    MODEL_IN_CODE_PATH,
-    '// This file is the starting point to define your models in code.\n',
-  );
-
   const packageManager = (await exists('bun.lockb')) ? 'bun' : 'npm';
   const packageManagerName = packageManager === 'bun' ? 'Bun' : 'npm';
 
@@ -53,11 +45,25 @@ export default async (positionals: Array<string>): Promise<void> => {
       }
     }
 
-    // Install the types package using the preferred package manager
-    if (packageManager === 'bun') {
-      await exec(`bun add @ronin-types/${spaceHandle} --dev`);
+    const packages = await getLocalPackages();
+    const doModelsExist = (await getModels(packages)).length > 0;
+
+    if (doModelsExist) {
+      // Install the types package using the preferred package manager
+      if (packageManager === 'bun') {
+        await exec(`bun add @ronin-types/${spaceHandle} --dev`);
+      } else {
+        await exec(`npm install @ronin-types/${spaceHandle} --save-dev`);
+      }
     } else {
-      await exec(`npm install @ronin-types/${spaceHandle} --save-dev`);
+      // Create ronin directories.
+      await fs.mkdir(MIGRATIONS_PATH, { recursive: true });
+
+      // Create a `schema/index.ts` file.
+      await fs.writeFile(
+        MODEL_IN_CODE_PATH,
+        '// This file is the starting point to define your models in code.\n',
+      );
     }
 
     // Add the types package to the project's TypeScript config if one exists

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -49,7 +49,7 @@ export default async (positionals: Array<string>): Promise<void> => {
     const doModelsExist = (await getModels(packages)).length > 0;
 
     if (doModelsExist) {
-      // Install the types package using the preferred package manager
+      // Install the types package using the preferred package manager.
       if (packageManager === 'bun') {
         await exec(`bun add @ronin-types/${spaceHandle} --dev`);
       } else {

--- a/src/utils/model.ts
+++ b/src/utils/model.ts
@@ -23,7 +23,7 @@ import type { Row } from '@ronin/engine/types';
  */
 export const getModels = async (
   packages: LocalPackages,
-  db: Database,
+  db?: Database,
   token?: string,
   space?: string,
   isLocal = true,
@@ -33,7 +33,7 @@ export const getModels = async (
 
   let rawResults: Array<Array<Row>>;
 
-  if (isLocal) {
+  if (isLocal && db) {
     rawResults = (await db.query(transaction.statements)).map((r) => r.rows);
   } else {
     try {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -339,6 +339,7 @@ describe('CLI', () => {
         spyOn(modelModule, 'getModels').mockResolvedValue([
           {
             slug: 'user',
+            // @ts-expect-error This is a mock.
             fields: [{ type: 'string', slug: 'name' }],
           },
         ]);

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -335,12 +335,26 @@ describe('CLI', () => {
         );
       };
 
-      test('should successfully initialize a project with Bun', async () => {
+      test('should successfully initialize a project with Bun when models exist', async () => {
+        spyOn(modelModule, 'getModels').mockResolvedValue([
+          {
+            slug: 'user',
+            fields: [{ type: 'string', slug: 'name' }],
+          },
+        ]);
+
         setupInitTest(true);
         await run({ version: '1.0.0' });
         expect(initModule.exec).toHaveBeenCalledWith(
           'bun add @ronin-types/test-space --dev',
         );
+      });
+
+      test('should successfully initialize a project with Bun when no models exist', async () => {
+        spyOn(modelModule, 'getModels').mockResolvedValue([]);
+
+        setupInitTest(true);
+        await run({ version: '1.0.0' });
 
         // Verify that writeFile was called for schema/index.ts.
         expect(fs.promises.writeFile).toHaveBeenCalledWith(
@@ -352,6 +366,14 @@ describe('CLI', () => {
       });
 
       test('should successfully initialize a project with npm', async () => {
+        spyOn(modelModule, 'getModels').mockResolvedValue([
+          {
+            slug: 'user',
+            // @ts-expect-error This is a mock
+            fields: [{ type: 'string', slug: 'name' }],
+          },
+        ]);
+
         setupInitTest(false);
         await run({ version: '1.0.0' });
         expect(initModule.exec).toHaveBeenCalledWith(
@@ -360,6 +382,14 @@ describe('CLI', () => {
       });
 
       test('should fail to initialize a project with unauthorized access', async () => {
+        spyOn(modelModule, 'getModels').mockResolvedValue([
+          {
+            slug: 'user',
+            // @ts-expect-error This is a mock
+            fields: [{ type: 'string', slug: 'name' }],
+          },
+        ]);
+
         setupInitTest();
 
         // Mock exec to throw unauthorized error

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -51,6 +51,7 @@ describe('CLI', () => {
     spyOn(fs, 'readdirSync').mockReturnValue(['migration-0001.ts', 'migration-0002.ts']);
     spyOn(fs, 'writeFileSync').mockImplementation(() => {});
     spyOn(fs, 'mkdirSync').mockImplementation(() => {});
+    spyOn(fs.promises, 'writeFile').mockResolvedValue();
   });
 
   afterEach(() => {
@@ -301,7 +302,7 @@ describe('CLI', () => {
         }
       });
 
-      const setupInitTest = (hasBun = true) => {
+      const setupInitTest = (hasBun = true): void => {
         process.argv = ['bun', 'ronin', 'init', 'test-space'];
 
         spyOn(fs.promises, 'access').mockImplementation((path) => {
@@ -339,6 +340,14 @@ describe('CLI', () => {
         await run({ version: '1.0.0' });
         expect(initModule.exec).toHaveBeenCalledWith(
           'bun add @ronin-types/test-space --dev',
+        );
+
+        // Verify that writeFile was called for schema/index.ts.
+        expect(fs.promises.writeFile).toHaveBeenCalledWith(
+          expect.stringContaining('schema/index.ts'),
+          expect.stringContaining(
+            '// This file is the starting point to define your models in code.',
+          ),
         );
       });
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -46,8 +46,8 @@ describe('CLI', () => {
       });
     });
 
-    // Prevent actually reading/writing files
-    // @ts-expect-error This is a mock
+    // Prevent actually reading/writing files.
+    // @ts-expect-error This is a mock.
     spyOn(fs, 'readdirSync').mockReturnValue(['migration-0001.ts', 'migration-0002.ts']);
     spyOn(fs, 'writeFileSync').mockImplementation(() => {});
     spyOn(fs, 'mkdirSync').mockImplementation(() => {});
@@ -317,8 +317,8 @@ describe('CLI', () => {
           return Promise.reject(new Error('File not found'));
         });
 
-        // Mock file operations
-        // @ts-expect-error This is a mock
+        // Mock file operations.
+        // @ts-expect-error This is a mock.
         spyOn(fs.promises, 'readFile').mockImplementation((path) => {
           if (path.toString().includes('.gitignore'))
             return Promise.resolve('node_modules\n');
@@ -330,7 +330,7 @@ describe('CLI', () => {
         spyOn(fs.promises, 'writeFile').mockResolvedValue();
 
         spyOn(initModule, 'exec').mockImplementation(
-          // @ts-expect-error This is a mock
+          // @ts-expect-error This is a mock.
           () => () => Promise.resolve({ stdout: '', stderr: '' }),
         );
       };
@@ -370,7 +370,7 @@ describe('CLI', () => {
         spyOn(modelModule, 'getModels').mockResolvedValue([
           {
             slug: 'user',
-            // @ts-expect-error This is a mock
+            // @ts-expect-error This is a mock.
             fields: [{ type: 'string', slug: 'name' }],
           },
         ]);
@@ -386,7 +386,7 @@ describe('CLI', () => {
         spyOn(modelModule, 'getModels').mockResolvedValue([
           {
             slug: 'user',
-            // @ts-expect-error This is a mock
+            // @ts-expect-error This is a mock.
             fields: [{ type: 'string', slug: 'name' }],
           },
         ]);
@@ -416,7 +416,7 @@ describe('CLI', () => {
         spyOn(modelModule, 'getModels').mockResolvedValue([
           {
             slug: 'user',
-            // @ts-expect-error This is a mock
+            // @ts-expect-error This is a mock.
             fields: [{ type: 'string', slug: 'name' }],
           },
         ]);
@@ -476,7 +476,7 @@ describe('CLI', () => {
       spyOn(modelModule, 'getModels').mockResolvedValue([
         {
           slug: 'user',
-          // @ts-expect-error This is a mock
+          // @ts-expect-error This is a mock.
           fields: convertObjectToArray({
             name: { type: 'string' },
           }),
@@ -699,7 +699,7 @@ describe('CLI', () => {
         spyOn(modelModule, 'getModels').mockResolvedValue([
           {
             slug: 'user',
-            // @ts-expect-error This is a mock
+            // @ts-expect-error This is a mock.
             fields: convertObjectToArray({
               name: { type: 'string' },
             }),
@@ -743,7 +743,7 @@ describe('CLI', () => {
         await run({ version: '1.0.0' });
 
         expect(
-          // @ts-expect-error This is a mock
+          // @ts-expect-error This is a mock.
           stderrSpy.mock.calls.some((call) => call[0].includes('Network error')),
         ).toBe(true);
       });
@@ -755,7 +755,7 @@ describe('CLI', () => {
         spyOn(modelModule, 'getModels').mockResolvedValue([
           {
             slug: 'user',
-            // @ts-expect-error This is a mock
+            // @ts-expect-error This is a mock.
             fields: convertObjectToArray({
               name: { type: 'string' },
             }),
@@ -798,7 +798,7 @@ describe('CLI', () => {
         spyOn(modelModule, 'getModels').mockResolvedValue([
           {
             slug: 'user',
-            // @ts-expect-error This is a mock
+            // @ts-expect-error This is a mock.
             fields: [{ type: 'string', slug: 'name' }],
           },
         ]);

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -59,23 +59,4 @@ describe('CLI Integration Tests', () => {
     expect(stderr.toString()).toContain('Please provide a space handle like this:');
     expect(stderr.toString()).toContain('$ ronin init my-space');
   });
-
-  test('should fail to initialize a project', async () => {
-    // Mock necessary files for a successful init
-    await fs.promises.writeFile(
-      path.join(tempDir, 'tsconfig.json'),
-      JSON.stringify({ compilerOptions: { types: [] } }, null, 2),
-    );
-
-    await fs.promises.writeFile(path.join(tempDir, '.gitignore'), 'node_modules\n');
-
-    const { stderr, exitCode } = await $`RONIN_TOKEN=test bun ${CLI_PATH} init test-space`
-      .nothrow()
-      .quiet();
-
-    expect(exitCode).toBe(1);
-    expect(stderr.toString()).toContain(
-      'You are not a member of the "test-space" space or the space doesn\'t exist.',
-    );
-  });
 });


### PR DESCRIPTION
When executing the `ronin init` command, if the target space already contains models, the types are automatically installed. Conversely, if there are no models present in the space, a directory is initialized for migrations, and a code definition file is created for the models.

