### PR TITLE
Only import necessary query types in migrations

### DIFF
--- a/src/utils/protocol.ts
+++ b/src/utils/protocol.ts
@@ -96,8 +96,8 @@ export class Protocol {
           usedQueryTypes.add(type);
         }
 
-        // We also need to check if for example a `get` query is used inside a `add` query.
-        // For example: `add.profiles.with(() => get.user({ "selecting": ["name"] }))`.
+        // We also need to check if a query type is used inside another query.
+        // For example: `add.model({slug: 'model1'}).with(() => get.model({slug: 'model2'}))`.
         if (query.includes(` ${type}.`)) {
           usedQueryTypes.add(type);
         }

--- a/src/utils/protocol.ts
+++ b/src/utils/protocol.ts
@@ -88,14 +88,28 @@ export class Protocol {
       'remove',
       'count',
     ];
-    const usedQueryTypes = queryTypes.filter((type) =>
-      this._roninQueries.some((query) => query.startsWith(`${type}.`)),
-    );
+    const usedQueryTypes = new Set<string>();
+
+    for (const query of this._roninQueries) {
+      for (const type of queryTypes) {
+        if (query.startsWith(`${type}.`)) {
+          usedQueryTypes.add(type);
+        }
+
+        // We also need to check if for example a `get` query is used inside a `add` query.
+        // For example: `add.profiles.with(() => get.user({ "selecting": ["name"] }))`.
+        if (query.includes(` ${type}.`)) {
+          usedQueryTypes.add(type);
+        }
+      }
+    }
+
+    const usedQueryTypesArray = Array.from(usedQueryTypes);
 
     // Only import the query types that are actually used
     const imports =
-      usedQueryTypes.length > 0
-        ? `import { ${usedQueryTypes.join(', ')} } from 'ronin';`
+      usedQueryTypesArray.length > 0
+        ? `import { ${usedQueryTypesArray.join(', ')} } from 'ronin';`
         : '';
 
     return `${imports}

--- a/tests/utils/protocol.test.ts
+++ b/tests/utils/protocol.test.ts
@@ -1,10 +1,14 @@
-import { describe, expect, jest, spyOn, test } from 'bun:test';
+import { afterEach, describe, expect, jest, spyOn, test } from 'bun:test';
 import fs, { type PathOrFileDescriptor } from 'node:fs';
 import { getLocalPackages } from '@/src/utils/misc';
 import { Protocol } from '@/src/utils/protocol';
 import type { Model, Statement } from '@ronin/compiler';
 
 describe('protocol', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   test('should initialize with empty queries when none are provided', async () => {
     const packages = await getLocalPackages();
 
@@ -158,6 +162,29 @@ describe('protocol', () => {
     expect(mixedFileContent).toContain('import { create, get, set } from "ronin";');
     expect(mixedFileContent).not.toContain('alter');
     expect(mixedFileContent).not.toContain('drop');
+  });
+
+  test('migration file should only import used query types with subqueries', async () => {
+    const packages = await getLocalPackages();
+    const fileName = 'migration_imports_test';
+
+    // Test with only create queries
+    const createQueries = [
+      "create.model({slug: 'model1'})",
+      "create.model({slug: 'model2'})",
+      "add.model({slug: 'model1'}).with(() => get.model({slug: 'model2'}))",
+    ];
+    const createProtocol = new Protocol(packages, createQueries);
+
+    // Mock `fs.mkdirSync` and `fs.writeFileSync`
+    spyOn(fs, 'mkdirSync').mockImplementation(() => {});
+    const writeFileSpy = spyOn(fs, 'writeFileSync').mockImplementation(() => {});
+
+    createProtocol.save(fileName);
+
+    // Check the content of the first call to `fs.writeFileSync`
+    const createFileContent = writeFileSpy.mock.calls[0][1] as string;
+    expect(createFileContent).toContain('import { add, create, get } from "ronin";');
   });
 
   test('load specific migration file', async () => {

--- a/tests/utils/protocol.test.ts
+++ b/tests/utils/protocol.test.ts
@@ -168,7 +168,6 @@ describe('protocol', () => {
     const packages = await getLocalPackages();
     const fileName = 'migration_imports_test';
 
-    // Test with only create queries
     const createQueries = [
       "create.model({slug: 'model1'})",
       "create.model({slug: 'model2'})",
@@ -176,13 +175,11 @@ describe('protocol', () => {
     ];
     const createProtocol = new Protocol(packages, createQueries);
 
-    // Mock `fs.mkdirSync` and `fs.writeFileSync`
     spyOn(fs, 'mkdirSync').mockImplementation(() => {});
     const writeFileSpy = spyOn(fs, 'writeFileSync').mockImplementation(() => {});
 
     createProtocol.save(fileName);
 
-    // Check the content of the first call to `fs.writeFileSync`
     const createFileContent = writeFileSpy.mock.calls[0][1] as string;
     expect(createFileContent).toContain('import { add, create, get } from "ronin";');
   });


### PR DESCRIPTION
The CLI was previously designed to automatically import only the necessary query types. However, it only verified if the queries started with the query type, which overlooked cases involving subqueries. For instance, a subquery like `add.model({slug: 'model1'}).with(() => get.model({slug: 'model2'}))` was not correctly handled. This PR addresses and resolves this issue.

