### PR TITLE
Mock global `.npmrc`and `bunfig.toml`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dist
 # Code coverage report
 coverage
 .ronin
+.ronin

--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,3 @@ dist
 # Code coverage report
 coverage
 .ronin
-.ronin

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -40,6 +40,8 @@ describe('CLI', () => {
     stderrSpy = spyOn(process.stderr, 'write').mockImplementation(() => true);
     exitSpy = spyOn(process, 'exit').mockImplementation(() => undefined as never);
     spyOn(console, 'table').mockImplementation(() => {});
+    // @ts-expect-error This is a mock.
+    spyOn(fs.promises, 'appendFile').mockImplementation(() => {});
     spyOn(sessionModule, 'getSession').mockImplementation(() => {
       return Promise.resolve({
         token: 'Bulgur',
@@ -53,7 +55,7 @@ describe('CLI', () => {
     spyOn(fs, 'mkdirSync').mockImplementation(() => {});
     spyOn(fs.promises, 'writeFile').mockResolvedValue();
 
-    // Mock reading .npmrc and bunfig.toml as empty files
+    // Mock reading `.npmrc` and `bunfig.toml` as empty files
     // @ts-expect-error This is a mock.
     spyOn(fs.promises, 'readFile').mockImplementation((filePath) => {
       if (typeof filePath === 'string') {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -52,6 +52,20 @@ describe('CLI', () => {
     spyOn(fs, 'writeFileSync').mockImplementation(() => {});
     spyOn(fs, 'mkdirSync').mockImplementation(() => {});
     spyOn(fs.promises, 'writeFile').mockResolvedValue();
+
+    // Mock reading .npmrc and bunfig.toml as empty files
+    // @ts-expect-error This is a mock.
+    spyOn(fs.promises, 'readFile').mockImplementation((filePath) => {
+      if (typeof filePath === 'string') {
+        if (filePath.includes('.npmrc')) return Promise.resolve('');
+        if (filePath.includes('bunfig.toml')) return Promise.resolve('');
+        if (filePath.toString().includes('.gitignore'))
+          return Promise.resolve('node_modules\n');
+        if (filePath.toString().includes('tsconfig.json'))
+          return Promise.resolve('{"compilerOptions":{"types":[]}}');
+      }
+      return Promise.resolve('{"token": "Bulgur"}');
+    });
   });
 
   afterEach(() => {


### PR DESCRIPTION
The tests did not run consistently across different machines because they depended on accessing global `npmrc` and `bufing.toml` files, which can differ between environments. 

Additionally, we mocked the `appendFile` function to prevent it from appending `.ronin` to `.gitignore` every time.

