### PR TITLE
Creating temp models caused undefined `name` and `pluralName`

### DIFF
--- a/src/utils/field.ts
+++ b/src/utils/field.ts
@@ -439,7 +439,11 @@ export const createFields = async (
             // @ts-expect-error This will work once the types are fixed.
             fields: convertArrayToObject(definedFields),
           },
-          { includeFields: existingFields },
+          {
+            includeFields: existingFields,
+            name: options?.name,
+            pluralName: options?.pluralName,
+          },
         ),
       );
       return diff;

--- a/src/utils/migration.ts
+++ b/src/utils/migration.ts
@@ -25,8 +25,6 @@ import type { Model } from '@ronin/compiler';
 export interface MigrationOptions {
   rename?: boolean;
   requiredDefault?: boolean | string;
-  name?: string;
-  pluralName?: string;
 }
 
 /**
@@ -49,7 +47,7 @@ export const IGNORED_FIELDS = [
  *
  * @param definedModels - The models defined locally.
  * @param existingModels - The models defined remotely.
- * @param rename - Optional flag to automatically rename models without prompting.
+ * @param options - Optional options for the migration.
  *
  * @returns An array of migration steps (as code strings).
  */

--- a/src/utils/migration.ts
+++ b/src/utils/migration.ts
@@ -25,6 +25,8 @@ import type { Model } from '@ronin/compiler';
 export interface MigrationOptions {
   rename?: boolean;
   requiredDefault?: boolean | string;
+  name?: string;
+  pluralName?: string;
 }
 
 /**
@@ -47,7 +49,7 @@ export const IGNORED_FIELDS = [
  *
  * @param definedModels - The models defined locally.
  * @param existingModels - The models defined remotely.
- * @param options - Optional options for the migration.
+ * @param Options - Optional flag to automatically rename models without prompting.
  *
  * @returns An array of migration steps (as code strings).
  */

--- a/tests/utils/apply.test.ts
+++ b/tests/utils/apply.test.ts
@@ -546,6 +546,16 @@ describe('apply', () => {
             'create.model({"slug":"RONIN_TEMP_a","fields":{"name":{"type":"string"},"age":{"type":"number","defaultValue":{"__RONIN_EXPRESSION":"random()"}}}})',
           );
 
+          expect(modelDiff[1]).toContain(
+            'add.RONIN_TEMP_a.with(() => get.a({"selecting":["name"]}))',
+          );
+
+          expect(modelDiff[2]).toContain('drop.model("a")');
+
+          expect(modelDiff[3]).toContain(
+            'alter.model("RONIN_TEMP_a").to({slug: "a", name: "A", pluralName: "As"})',
+          );
+
           expect(models).toHaveLength(1);
           // @ts-expect-error This is defined!
           expect(models[0]?.fields[1].defaultValue).toEqual({
@@ -663,9 +673,12 @@ describe('apply', () => {
             }
           }
 
-          expect(modelDiff[0]).toContain(
+          expect(modelDiff).toEqual([
             'alter.model(\'a\').create.field({"slug":"RONIN_TEMP_age","type":"number","defaultValue":{"__RONIN_EXPRESSION":"random()"}})',
-          );
+            'set.a.to.RONIN_TEMP_age(f => f.age)',
+            'alter.model("a").drop.field("age")',
+            'alter.model("a").alter.field("RONIN_TEMP_age").to({slug: "age"})',
+          ]);
 
           expect(models).toHaveLength(1);
           // @ts-expect-error This is defined!

--- a/tests/utils/migration.test.ts
+++ b/tests/utils/migration.test.ts
@@ -41,8 +41,6 @@ describe('migration', () => {
       // It is not recognized as a model.
       const modelDiff = await diffModels([Account], [Account2], {
         rename: true,
-        name: 'Account',
-        pluralName: 'Accounts',
       });
 
       expect(modelDiff).toHaveLength(4);
@@ -88,10 +86,7 @@ describe('migration', () => {
 
     test('generates migration steps when meta model properties change', async () => {
       // It is not recognized as a model.
-      const modelDiff = await diffModels([TestC], [TestA], {
-        name: 'ThisIsACoolModel',
-        pluralName: 'ThisIsACoolModels',
-      });
+      const modelDiff = await diffModels([TestC], [TestA]);
 
       expect(modelDiff).toHaveLength(4);
       expect(modelDiff).toStrictEqual([
@@ -105,10 +100,7 @@ describe('migration', () => {
 
     test('generates migration steps when field definitions differ', async () => {
       // It is not recognized as a model.
-      const modelDiff = await diffModels([Account], [Account2], {
-        name: 'Account',
-        pluralName: 'Accounts',
-      });
+      const modelDiff = await diffModels([Account], [Account2]);
 
       expect(modelDiff).toHaveLength(4);
       expect(modelDiff).toStrictEqual([


### PR DESCRIPTION
This pull request addresses an issue related to the renaming of temporary models. When creating temporary models, it is necessary to rename the model from `ronin_temp_yourModelSlug` to `yourModelSlug`. Additionally, the `name` and `pluralName` attributes need to be updated, as they are derived from the compiler. Previously, altering the model slug and names resulted in `undefined` values for `name` and `pluralName`. This PR fixes this bug by ensuring that the `name` and `pluralName` are correctly set during the renaming process.

