### PR TITLE
Only keep quotes in the migrations if needed

### DIFF
--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -14,6 +14,7 @@ export const detectFormatConfig = (): {
   singleQuote: boolean;
   semi: boolean;
   configSource: string;
+  quoteProps: 'asNeeded' | 'preserve' | 'consistent';
 } => {
   const configFiles = ['biome.json', '.prettierrc.json', '.eslintrc.json', '.prettierrc'];
 
@@ -33,6 +34,7 @@ export const detectFormatConfig = (): {
             singleQuote: config.javascript?.formatter?.quoteStyle === 'single',
             semi: config.javascript?.formatter?.semicolons === 'always',
             configSource: path.basename(file),
+            quoteProps: 'asNeeded',
           };
         }
 
@@ -44,6 +46,7 @@ export const detectFormatConfig = (): {
             singleQuote: config.rules?.quotes?.[1] === 'single',
             semi: config.rules?.semi?.[0] === 'error' || config.rules?.semi?.[0] === 2,
             configSource: path.basename(file),
+            quoteProps: 'asNeeded',
           };
         }
 
@@ -54,6 +57,7 @@ export const detectFormatConfig = (): {
           singleQuote: config.singleQuote ?? true,
           semi: config.semi ?? true,
           configSource: path.basename(file),
+          quoteProps: 'asNeeded',
         };
       } catch (err) {
         console.log(`Error parsing ${file}: ${err}`);
@@ -68,6 +72,7 @@ export const detectFormatConfig = (): {
     singleQuote: true,
     semi: true,
     configSource: 'default',
+    quoteProps: 'asNeeded',
   };
 };
 
@@ -85,6 +90,7 @@ export const formatCode = (code: string): string => {
       tabWidth: config.tabWidth,
       singleQuote: config.singleQuote,
       semi: config.semi,
+      quoteProps: config.quoteProps,
     },
   });
 

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -34,7 +34,7 @@ export const detectFormatConfig = (): {
             singleQuote: config.javascript?.formatter?.quoteStyle === 'single',
             semi: config.javascript?.formatter?.semicolons === 'always',
             configSource: path.basename(file),
-            quoteProps: 'asNeeded',
+            quoteProps: config.javascript?.formatter?.quoteProps ?? 'asNeeded',
           };
         }
 
@@ -46,7 +46,7 @@ export const detectFormatConfig = (): {
             singleQuote: config.rules?.quotes?.[1] === 'single',
             semi: config.rules?.semi?.[0] === 'error' || config.rules?.semi?.[0] === 2,
             configSource: path.basename(file),
-            quoteProps: 'asNeeded',
+            quoteProps: config.rules?.['quote-props']?.[1] ?? 'asNeeded',
           };
         }
 
@@ -57,7 +57,7 @@ export const detectFormatConfig = (): {
           singleQuote: config.singleQuote ?? true,
           semi: config.semi ?? true,
           configSource: path.basename(file),
-          quoteProps: 'asNeeded',
+          quoteProps: config.quoteProps ?? 'asNeeded',
         };
       } catch (err) {
         console.log(`Error parsing ${file}: ${err}`);

--- a/tests/utils/format.test.ts
+++ b/tests/utils/format.test.ts
@@ -20,6 +20,7 @@ describe('format', () => {
       singleQuote: true,
       semi: true,
       configSource: 'default',
+      quoteProps: 'asNeeded',
     });
 
     // Restore original
@@ -54,6 +55,7 @@ describe('format', () => {
       singleQuote: true,
       semi: true,
       configSource: 'biome.json',
+      quoteProps: 'asNeeded',
     });
 
     // Restore originals
@@ -84,6 +86,7 @@ describe('format', () => {
       singleQuote: true,
       semi: true,
       configSource: '.eslintrc.json',
+      quoteProps: 'asNeeded',
     });
 
     // Restore originals
@@ -104,6 +107,7 @@ describe('format', () => {
         tabWidth: 4,
         singleQuote: false,
         semi: false,
+        quoteProps: 'asNeeded',
       });
 
     const config = detectFormatConfig();
@@ -113,6 +117,7 @@ describe('format', () => {
       singleQuote: false,
       semi: false,
       configSource: '.prettierrc.json',
+      quoteProps: 'asNeeded',
     });
 
     // Restore originals
@@ -125,6 +130,13 @@ describe('format', () => {
     const formatted = await formatCode(input);
     expect(formatted).toContain('function test()');
     expect(formatted).toContain(';');
+  });
+
+  test('drop double quotes for object keys', () => {
+    const input = 'const test = {"name": "John", "age": 30}';
+    const formatted = formatCode(input);
+    expect(formatted).toContain('name: "John"');
+    expect(formatted).toContain('age: 30');
   });
 
   test('detectFormatConfig should handle broken config files', () => {
@@ -153,6 +165,7 @@ describe('format', () => {
       singleQuote: true,
       semi: true,
       configSource: 'default',
+      quoteProps: 'asNeeded',
     });
 
     // Should log error about broken config


### PR DESCRIPTION
This update modifies the way we handle quote properties by reading them directly from the formatter configurations. By default, quotes are now omitted when they are not necessary.

