### PR TITLE
Re-generate types after running `ronin apply`

### DIFF
--- a/src/commands/apply.ts
+++ b/src/commands/apply.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import types from '@/src/commands/types';
 import { initializeDatabase } from '@/src/utils/database';
 import type { MigrationFlags } from '@/src/utils/migration';
 import { MIGRATIONS_PATH, getLocalPackages } from '@/src/utils/misc';
@@ -82,6 +83,10 @@ export default async (
     );
 
     spinner.succeed('Successfully applied migration');
+
+    // If desired, generate new TypeScript types
+    if (flags.types) await types(appToken, sessionToken);
+
     process.exit(0);
   } catch (err) {
     const message =

--- a/src/commands/apply.ts
+++ b/src/commands/apply.ts
@@ -85,7 +85,7 @@ export default async (
     spinner.succeed('Successfully applied migration');
 
     // If desired, generate new TypeScript types
-    if (flags.types) await types(appToken, sessionToken);
+    if (!flags['skip-types']) await types(appToken, sessionToken);
 
     process.exit(0);
   } catch (err) {

--- a/src/utils/info.ts
+++ b/src/utils/info.ts
@@ -31,7 +31,6 @@ export const printHelp = (): Promise<void> => {
       -h, --help                          Shows this help message
       -v, --version                       Shows the version of the CLI that is currently installed
       -d, --debug                         Shows additional debugging information
-      -t, --types                         Run the \`types\` command on completon
   `;
   console.log(text);
   process.exit(0);

--- a/src/utils/info.ts
+++ b/src/utils/info.ts
@@ -31,6 +31,7 @@ export const printHelp = (): Promise<void> => {
       -h, --help                          Shows this help message
       -v, --version                       Shows the version of the CLI that is currently installed
       -d, --debug                         Shows additional debugging information
+      -t, --types                         Run the \`types\` command on completon
   `;
   console.log(text);
   process.exit(0);

--- a/src/utils/migration.ts
+++ b/src/utils/migration.ts
@@ -439,7 +439,7 @@ export const MIGRATION_FLAGS = {
   sql: { type: 'boolean', short: 's', default: false },
   local: { type: 'boolean', short: 'l', default: false },
   apply: { type: 'boolean', short: 'a', default: false },
-  types: { type: 'boolean', short: 't', default: true },
+  'skip-types': { type: 'boolean', default: false },
 } satisfies NonNullable<Parameters<typeof parseArgs>[0]>['options'];
 
 /**

--- a/src/utils/migration.ts
+++ b/src/utils/migration.ts
@@ -439,6 +439,7 @@ export const MIGRATION_FLAGS = {
   sql: { type: 'boolean', short: 's', default: false },
   local: { type: 'boolean', short: 'l', default: false },
   apply: { type: 'boolean', short: 'a', default: false },
+  types: { type: 'boolean', short: 't', default: true },
 } satisfies NonNullable<Parameters<typeof parseArgs>[0]>['options'];
 
 /**

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -802,6 +802,17 @@ describe('CLI', () => {
               call[0].includes('Successfully applied migration'),
           ),
         ).toBe(true);
+        expect(
+          stderrSpy.mock.calls.some(
+            (call) => typeof call[0] === 'string' && call[0].includes('Generating types'),
+          ),
+        ).toBe(true);
+        expect(
+          stderrSpy.mock.calls.some(
+            (call) =>
+              typeof call[0] === 'string' && call[0].includes('Failed to generate types'),
+          ),
+        ).toBe(true);
       });
 
       test('try to apply with non-existent migration file', async () => {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -815,6 +815,56 @@ describe('CLI', () => {
         ).toBe(true);
       });
 
+      test('skip generating types', async () => {
+        process.argv = ['bun', 'ronin', 'apply', '--local', '--skip-types'];
+
+        spyOn(spaceModule, 'getOrSelectSpaceId').mockResolvedValue('test-space');
+        spyOn(modelModule, 'getModels').mockResolvedValue([
+          {
+            slug: 'user',
+            // @ts-expect-error This is a mock.
+            fields: convertObjectToArray({
+              name: { type: 'string' },
+            }),
+          },
+        ]);
+
+        spyOn(fs, 'existsSync').mockImplementation((path) =>
+          path.toString().includes('migration-fixture.ts'),
+        );
+        spyOn(selectModule, 'select').mockResolvedValue('migration-0001.ts');
+        spyOn(path, 'resolve').mockReturnValue(
+          path.join(process.cwd(), 'tests/fixtures/migration-fixture.ts'),
+        );
+
+        await run({ version: '1.0.0' });
+
+        expect(
+          stderrSpy.mock.calls.some(
+            ([call]) =>
+              typeof call === 'string' &&
+              call.includes('Applying migration to local database'),
+          ),
+        ).toBe(true);
+        expect(
+          stderrSpy.mock.calls.some(
+            ([call]) =>
+              typeof call === 'string' && call.includes('Successfully applied migration'),
+          ),
+        ).toBe(true);
+        expect(
+          stderrSpy.mock.calls.some(
+            ([call]) => typeof call === 'string' && call.includes('Generating types'),
+          ),
+        ).toBe(false);
+        expect(
+          stderrSpy.mock.calls.some(
+            ([call]) =>
+              typeof call === 'string' && call.includes('Failed to generate types'),
+          ),
+        ).toBe(false);
+      });
+
       test('try to apply with non-existent migration file', async () => {
         process.argv = ['bun', 'ronin', 'apply'];
 


### PR DESCRIPTION
This change updates the `apply` command to also run the `types` command straight after in order to update the generated TypeScript types.

This can also be skipped by disabling the new `--types` global flag that is enabled by default.