### PR TITLE
Upgrade RONIN engine

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8,7 +8,7 @@
         "@dprint/typescript": "0.93.3",
         "@iarna/toml": "2.2.5",
         "@inquirer/prompts": "7.2.3",
-        "@ronin/engine": "0.0.27",
+        "@ronin/engine": "0.1.16",
         "chalk-template": "1.1.0",
         "get-port": "7.1.0",
         "ini": "5.0.0",
@@ -187,7 +187,7 @@
 
     "@ronin/compiler": ["@ronin/compiler@0.17.17", "", {}, "sha512-uq17FQzCl6HeHoSsSkoXU2Enl8WfQd6uCC6sSGFRR171VbV6HHinW322KdlF1hN0khbYBoLoC/SNwXpfx7J/VQ=="],
 
-    "@ronin/engine": ["@ronin/engine@0.0.27", "", { "dependencies": { "zod": "3.23.8" } }, "sha512-ArUFnfNH6pVZb3nQStDNZ2p2m4j9QXQTxPM+BrCB6mMYShXrEv9Ke4DiJb+js0IuVhydWWYyA1sql4Nf0IWY5Q=="],
+    "@ronin/engine": ["@ronin/engine@0.1.16", "", { "dependencies": { "zod": "3.24.1" } }, "sha512-u1+MNPhj5XtLLCXcDNq6dlcYyb0B/VHndyZOJzFWPEXIIWj5ULdAHJ04VT/Gvmjxb3UlBN0EZIgA1ycNL8H5+w=="],
 
     "@ronin/syntax": ["@ronin/syntax@0.2.36", "", {}, "sha512-UddNTyCIEf9hkKHjuZzDgG92R05Yq+CCMlkVUjlDMYsnlvotuWtq7434Uy5j3w7K9XEP98rwjRdItq96pXhpmQ=="],
 
@@ -419,11 +419,13 @@
 
     "yoctocolors-cjs": ["yoctocolors-cjs@2.1.2", "", {}, "sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA=="],
 
-    "zod": ["zod@3.23.8", "", {}, "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g=="],
+    "zod": ["zod@3.24.1", "", {}, "sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A=="],
 
     "@isaacs/cliui/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
 
     "@isaacs/cliui/wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
+
+    "@ronin/cli/@ronin/engine": ["@ronin/engine@0.0.27", "", { "dependencies": { "zod": "3.23.8" } }, "sha512-ArUFnfNH6pVZb3nQStDNZ2p2m4j9QXQTxPM+BrCB6mMYShXrEv9Ke4DiJb+js0IuVhydWWYyA1sql4Nf0IWY5Q=="],
 
     "log-symbols/is-unicode-supported": ["is-unicode-supported@1.3.0", "", {}, "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ=="],
 
@@ -444,6 +446,8 @@
     "@isaacs/cliui/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
 
     "@isaacs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@6.2.1", "", {}, "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug=="],
+
+    "@ronin/cli/@ronin/engine/zod": ["zod@3.23.8", "", {}, "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g=="],
 
     "string-width-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@dprint/typescript": "0.93.3",
     "@iarna/toml": "2.2.5",
     "@inquirer/prompts": "7.2.3",
-    "@ronin/engine": "0.0.27",
+    "@ronin/engine": "0.1.16",
     "chalk-template": "1.1.0",
     "get-port": "7.1.0",
     "ini": "5.0.0",

--- a/src/commands/apply.ts
+++ b/src/commands/apply.ts
@@ -9,7 +9,7 @@ import { Protocol } from '@/src/utils/protocol';
 import { getOrSelectSpaceId } from '@/src/utils/space';
 import { spinner as ora } from '@/src/utils/spinner';
 import { select } from '@inquirer/prompts';
-import type { Database } from '@ronin/engine';
+import type { Database } from '@ronin/engine/resources';
 
 /**
  * Applies a migration file to the database.

--- a/src/utils/database.ts
+++ b/src/utils/database.ts
@@ -1,7 +1,9 @@
 import fs from 'node:fs';
 import type { LocalPackages } from '@/src/utils/misc';
-import { type Database, Engine } from '@ronin/engine';
+import { Engine } from '@ronin/engine';
+import { BunDriver } from '@ronin/engine/drivers/bun';
 import { MemoryResolver } from '@ronin/engine/resolvers/memory';
+import type { Database } from '@ronin/engine/resources';
 
 /**
  * Initializes a new database instance.
@@ -18,7 +20,8 @@ export const initializeDatabase = async (
   const { Transaction, ROOT_MODEL } = packages.compiler;
 
   const engine = new Engine({
-    resolvers: [(engine) => new MemoryResolver(engine)],
+    driver: (engine): BunDriver => new BunDriver({ engine }),
+    resolvers: [(engine) => new MemoryResolver({ engine })],
   });
 
   const transaction = new Transaction([
@@ -32,7 +35,7 @@ export const initializeDatabase = async (
   if (fs.existsSync(fsPath)) {
     const file = fs.readFileSync(fsPath);
     const buffer = new Uint8Array(file);
-    await db.replaceContents(buffer);
+    await db.setContents(buffer);
   }
 
   try {

--- a/src/utils/model.ts
+++ b/src/utils/model.ts
@@ -8,8 +8,7 @@ import {
 } from '@/src/utils/misc';
 import { spinner } from '@/src/utils/spinner';
 import type { Model } from '@ronin/compiler';
-import type { Database } from '@ronin/engine';
-import type { Row } from '@ronin/engine/types';
+import type { Database, Row } from '@ronin/engine/resources';
 
 /**
  * Fetches and formats schema models from either production API or local database.

--- a/tests/fixtures/utils.ts
+++ b/tests/fixtures/utils.ts
@@ -3,11 +3,14 @@ import { type LocalPackages, getLocalPackages } from '@/src/utils/misc';
 import { convertModelToObjectFields, getModels } from '@/src/utils/model';
 import { Protocol } from '@/src/utils/protocol';
 import { type Model, type Statement, Transaction } from '@ronin/compiler';
-import { type Database, Engine } from '@ronin/engine';
+import { Engine } from '@ronin/engine';
+import { BunDriver } from '@ronin/engine/drivers/bun';
 import { MemoryResolver } from '@ronin/engine/resolvers/memory';
+import type { Database } from '@ronin/engine/resources';
 
 const engine = new Engine({
-  resolvers: [(engine) => new MemoryResolver(engine)],
+  driver: (engine): BunDriver => new BunDriver({ engine }),
+  resolvers: [(engine) => new MemoryResolver({ engine })],
 });
 
 /**

--- a/tests/utils/apply.test.ts
+++ b/tests/utils/apply.test.ts
@@ -34,7 +34,7 @@ import { getRowCount, getSQLTables, getTableRows, runMigration } from '@/fixture
 import { applyMigrationStatements } from '@/src/commands/apply';
 import type { MigrationFlags } from '@/src/utils/migration';
 import { getLocalPackages } from '@/src/utils/misc';
-import type { Database } from '@ronin/engine';
+import type { Database } from '@ronin/engine/resources';
 import type { Model } from 'ronin/schema';
 import { model, number, random, string } from 'ronin/schema';
 const packages = await getLocalPackages();


### PR DESCRIPTION
This change upgrades the `@ronin/engine` dependency to version `0.1.16` & subsequently includes some minor refactoring to support the latest api changes as part of the upgrade.