### PR TITLE
Drop all models migration with `--force-drop`

### DIFF
--- a/src/commands/diff.ts
+++ b/src/commands/diff.ts
@@ -28,6 +28,10 @@ export default async (
     throw new Error('Cannot run `--apply` and `--clean` at the same time');
   }
 
+  if (flags.clean && flags.nuke) {
+    throw new Error('Cannot run `--nuke` and `--clean` at the same time');
+  }
+
   let status: Status = 'readingConfig';
   spinner.text = 'Reading configuration';
   const modelsInCodePath =
@@ -46,7 +50,7 @@ export default async (
       flags.clean
         ? []
         : getModels(packages, db, appToken ?? sessionToken, space, flags.local),
-      getModelDefinitions(modelsInCodePath),
+      flags.nuke ? [] : getModelDefinitions(modelsInCodePath),
     ]);
 
     if (flags.debug) {

--- a/src/commands/diff.ts
+++ b/src/commands/diff.ts
@@ -28,8 +28,8 @@ export default async (
     throw new Error('Cannot run `--apply` and `--clean` at the same time');
   }
 
-  if (flags.clean && flags.nuke) {
-    throw new Error('Cannot run `--nuke` and `--clean` at the same time');
+  if (flags.clean && flags.teardown) {
+    throw new Error('Cannot run `--teardown` and `--clean` at the same time');
   }
 
   let status: Status = 'readingConfig';
@@ -50,7 +50,7 @@ export default async (
       flags.clean
         ? []
         : getModels(packages, db, appToken ?? sessionToken, space, flags.local),
-      flags.nuke ? [] : getModelDefinitions(modelsInCodePath),
+      flags.teardown ? [] : getModelDefinitions(modelsInCodePath),
     ]);
 
     if (flags.debug) {

--- a/src/commands/diff.ts
+++ b/src/commands/diff.ts
@@ -24,12 +24,12 @@ export default async (
   flags: MigrationFlags,
   positionals: Array<string>,
 ): Promise<void> => {
-  if (flags.clean && flags.apply) {
-    throw new Error('Cannot run `--apply` and `--clean` at the same time');
+  if (flags['force-create'] && flags.apply) {
+    throw new Error('Cannot run `--apply` and `--force-create` at the same time');
   }
 
-  if (flags.clean && flags.teardown) {
-    throw new Error('Cannot run `--teardown` and `--clean` at the same time');
+  if (flags['force-drop'] && flags['force-create']) {
+    throw new Error('Cannot run `--force-drop` and `--force-create` at the same time');
   }
 
   let status: Status = 'readingConfig';
@@ -47,10 +47,10 @@ export default async (
     spinner.text = 'Comparing models';
 
     const [existingModels, definedModels] = await Promise.all([
-      flags.clean
+      flags['force-create']
         ? []
         : getModels(packages, db, appToken ?? sessionToken, space, flags.local),
-      flags.teardown ? [] : getModelDefinitions(modelsInCodePath),
+      flags['force-drop'] ? [] : getModelDefinitions(modelsInCodePath),
     ]);
 
     if (flags.debug) {

--- a/src/utils/info.ts
+++ b/src/utils/info.ts
@@ -32,7 +32,7 @@ export const printHelp = (): Promise<void> => {
       -v, --version                       Shows the version of the CLI that is currently installed
       -d, --debug                         Shows additional debugging information
       -c, --clean                         Creates the migration against a clean database
-      -n, --nuke                          Creates a migration that drops all models
+      -r, --recreate                      Creates a migration that drops all models
   `;
   console.log(text);
   process.exit(0);

--- a/src/utils/info.ts
+++ b/src/utils/info.ts
@@ -32,6 +32,7 @@ export const printHelp = (): Promise<void> => {
       -v, --version                       Shows the version of the CLI that is currently installed
       -d, --debug                         Shows additional debugging information
       -c, --clean                         Creates the migration against a clean database
+      -n, --nuke                          Creates a migration that drops all models
   `;
   console.log(text);
   process.exit(0);

--- a/src/utils/info.ts
+++ b/src/utils/info.ts
@@ -31,8 +31,9 @@ export const printHelp = (): Promise<void> => {
       -h, --help                          Shows this help message
       -v, --version                       Shows the version of the CLI that is currently installed
       -d, --debug                         Shows additional debugging information
-      -c, --clean                         Creates the migration against a clean database
-      -t, --teardown                      Creates a migration that drops all models
+      -c, --force-create                  Creates the migration against a clean database
+      -d, --force-drop                    Creates a migration that drops all models
+      -s, --skip-types                    Skip type generation after applying the migration
   `;
   console.log(text);
   process.exit(0);

--- a/src/utils/info.ts
+++ b/src/utils/info.ts
@@ -32,7 +32,7 @@ export const printHelp = (): Promise<void> => {
       -v, --version                       Shows the version of the CLI that is currently installed
       -d, --debug                         Shows additional debugging information
       -c, --clean                         Creates the migration against a clean database
-      -r, --recreate                      Creates a migration that drops all models
+      -t, --teardown                      Creates a migration that drops all models
   `;
   console.log(text);
   process.exit(0);

--- a/src/utils/migration.ts
+++ b/src/utils/migration.ts
@@ -441,6 +441,7 @@ export const MIGRATION_FLAGS = {
   apply: { type: 'boolean', short: 'a', default: false },
   'skip-types': { type: 'boolean', default: false },
   clean: { type: 'boolean', short: 'c', default: false },
+  nuke: { type: 'boolean', short: 'n', default: false },
 } satisfies NonNullable<Parameters<typeof parseArgs>[0]>['options'];
 
 /**

--- a/src/utils/migration.ts
+++ b/src/utils/migration.ts
@@ -441,7 +441,7 @@ export const MIGRATION_FLAGS = {
   apply: { type: 'boolean', short: 'a', default: false },
   'skip-types': { type: 'boolean', default: false },
   clean: { type: 'boolean', short: 'c', default: false },
-  nuke: { type: 'boolean', short: 'n', default: false },
+  recreate: { type: 'boolean', short: 'r', default: false },
 } satisfies NonNullable<Parameters<typeof parseArgs>[0]>['options'];
 
 /**

--- a/src/utils/migration.ts
+++ b/src/utils/migration.ts
@@ -440,8 +440,8 @@ export const MIGRATION_FLAGS = {
   local: { type: 'boolean', short: 'l', default: false },
   apply: { type: 'boolean', short: 'a', default: false },
   'skip-types': { type: 'boolean', default: false },
-  clean: { type: 'boolean', short: 'c', default: false },
-  teardown: { type: 'boolean', short: 't', default: false },
+  'force-drop': { type: 'boolean', short: 'd', default: false },
+  'force-create': { type: 'boolean', short: 'c', default: false },
 } satisfies NonNullable<Parameters<typeof parseArgs>[0]>['options'];
 
 /**

--- a/src/utils/migration.ts
+++ b/src/utils/migration.ts
@@ -441,7 +441,7 @@ export const MIGRATION_FLAGS = {
   apply: { type: 'boolean', short: 'a', default: false },
   'skip-types': { type: 'boolean', default: false },
   clean: { type: 'boolean', short: 'c', default: false },
-  recreate: { type: 'boolean', short: 'r', default: false },
+  teardown: { type: 'boolean', short: 't', default: false },
 } satisfies NonNullable<Parameters<typeof parseArgs>[0]>['options'];
 
 /**

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -709,6 +709,31 @@ describe('CLI', () => {
           );
         }
       });
+
+      test('nuke flag', async () => {
+        process.argv = ['bun', 'ronin', 'diff', '--nuke'];
+        setupMigrationTest();
+
+        await run({ version: '1.0.0' });
+
+        expect(writeFileSyncSpy.mock.calls[0][1]).toContain(
+          `import { drop } from \"ronin\";\n\nexport default () => [\n  drop.model(\"user\"),\n];\n`,
+        );
+      });
+
+      test('nuke flag with clean flag', async () => {
+        process.argv = ['bun', 'ronin', 'diff', '--nuke', '--clean'];
+        setupMigrationTest();
+
+        try {
+          await run({ version: '1.0.0' });
+        } catch (error) {
+          expect(error).toBeInstanceOf(Error);
+          expect((error as Error).message).toContain(
+            'Cannot run `--nuke` and `--clean` at the same time',
+          );
+        }
+      });
     });
 
     describe('apply', () => {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -710,8 +710,8 @@ describe('CLI', () => {
         }
       });
 
-      test('nuke flag', async () => {
-        process.argv = ['bun', 'ronin', 'diff', '--nuke'];
+      test('recreate flag', async () => {
+        process.argv = ['bun', 'ronin', 'diff', '--recreate'];
         setupMigrationTest();
 
         await run({ version: '1.0.0' });
@@ -721,8 +721,8 @@ describe('CLI', () => {
         );
       });
 
-      test('nuke flag with clean flag', async () => {
-        process.argv = ['bun', 'ronin', 'diff', '--nuke', '--clean'];
+      test('recreate flag with clean flag', async () => {
+        process.argv = ['bun', 'ronin', 'diff', '--recreate', '--clean'];
         setupMigrationTest();
 
         try {
@@ -730,7 +730,7 @@ describe('CLI', () => {
         } catch (error) {
           expect(error).toBeInstanceOf(Error);
           expect((error as Error).message).toContain(
-            'Cannot run `--nuke` and `--clean` at the same time',
+            'Cannot run `--recreate` and `--clean` at the same time',
           );
         }
       });

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -685,8 +685,8 @@ describe('CLI', () => {
         ).toBe(true);
       });
 
-      test('clean flag', async () => {
-        process.argv = ['bun', 'ronin', 'diff', '--clean'];
+      test('force-create flag', async () => {
+        process.argv = ['bun', 'ronin', 'diff', '--force-create'];
         setupMigrationTest();
 
         await run({ version: '1.0.0' });
@@ -696,8 +696,8 @@ describe('CLI', () => {
         );
       });
 
-      test('clean flag with apply flag', async () => {
-        process.argv = ['bun', 'ronin', 'diff', '--clean', '--apply'];
+      test('force-create flag with apply flag', async () => {
+        process.argv = ['bun', 'ronin', 'diff', '--force-create', '--apply'];
         setupMigrationTest();
 
         try {
@@ -705,13 +705,13 @@ describe('CLI', () => {
         } catch (error) {
           expect(error).toBeInstanceOf(Error);
           expect((error as Error).message).toContain(
-            'Cannot run `--apply` and `--clean` at the same time',
+            'Cannot run `--apply` and `--force-create` at the same time',
           );
         }
       });
 
-      test('teardown flag', async () => {
-        process.argv = ['bun', 'ronin', 'diff', '--teardown'];
+      test('force-drop flag', async () => {
+        process.argv = ['bun', 'ronin', 'diff', '--force-drop'];
         setupMigrationTest();
 
         await run({ version: '1.0.0' });
@@ -721,8 +721,8 @@ describe('CLI', () => {
         );
       });
 
-      test('teardown flag with clean flag', async () => {
-        process.argv = ['bun', 'ronin', 'diff', '--teardown', '--clean'];
+      test('force-drop flag with force-create flag', async () => {
+        process.argv = ['bun', 'ronin', 'diff', '--force-drop', '--force-create'];
         setupMigrationTest();
 
         try {
@@ -730,7 +730,7 @@ describe('CLI', () => {
         } catch (error) {
           expect(error).toBeInstanceOf(Error);
           expect((error as Error).message).toContain(
-            'Cannot run `--teardown` and `--clean` at the same time',
+            'Cannot run `--force-drop` and `--force-create` at the same time',
           );
         }
       });

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -710,8 +710,8 @@ describe('CLI', () => {
         }
       });
 
-      test('recreate flag', async () => {
-        process.argv = ['bun', 'ronin', 'diff', '--recreate'];
+      test('teardown flag', async () => {
+        process.argv = ['bun', 'ronin', 'diff', '--teardown'];
         setupMigrationTest();
 
         await run({ version: '1.0.0' });
@@ -721,8 +721,8 @@ describe('CLI', () => {
         );
       });
 
-      test('recreate flag with clean flag', async () => {
-        process.argv = ['bun', 'ronin', 'diff', '--recreate', '--clean'];
+      test('teardown flag with clean flag', async () => {
+        process.argv = ['bun', 'ronin', 'diff', '--teardown', '--clean'];
         setupMigrationTest();
 
         try {
@@ -730,7 +730,7 @@ describe('CLI', () => {
         } catch (error) {
           expect(error).toBeInstanceOf(Error);
           expect((error as Error).message).toContain(
-            'Cannot run `--recreate` and `--clean` at the same time',
+            'Cannot run `--teardown` and `--clean` at the same time',
           );
         }
       });


### PR DESCRIPTION
With the `--force-drop` flag we can now create migrations which drop all models. Also `--clean` has been renamed to `--force-create`.