### PR TITLE
Free up "model" slug for models

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -22,7 +22,7 @@
         "@types/bun": "1.2.1",
         "@types/ini": "4.1.1",
         "bun-bagel": "1.1.0",
-        "ronin": "6.4.11",
+        "ronin": "6.4.12",
         "tsup": "8.3.6",
         "typescript": "5.7.3",
       },
@@ -187,7 +187,7 @@
 
     "@ronin/cli": ["@ronin/cli@0.3.2", "", { "dependencies": { "@dprint/formatter": "0.4.1", "@dprint/typescript": "0.93.3", "@iarna/toml": "2.2.5", "@inquirer/prompts": "7.2.3", "@ronin/engine": "0.1.16", "chalk-template": "1.1.0", "get-port": "7.1.0", "ini": "5.0.0", "json5": "2.2.3", "open": "10.1.0", "ora": "8.1.1", "resolve-from": "5.0.0" } }, "sha512-CBSDhRtd7BkRd4JO5s4b/AUXkw75nnUiV8LSKwNQxcYZFlcEWbr5xWfnxF1zP3Iv1uGpZTvzCI6naeAePSGmZA=="],
 
-    "@ronin/compiler": ["@ronin/compiler@0.17.22", "", {}, "sha512-w8Q2NUKzhbwKpiM1LXJWOM5iBtvfRsf1wNcWo+gYRrhLx1x5TBgL0Or2Py/+C4+2fkgh+iR5VcoAAO4XCWo7Aw=="],
+    "@ronin/compiler": ["@ronin/compiler@0.18.0", "", {}, "sha512-r6s90ylJWwpTJdJ+GOwku2DOaelgKJTn90RGSr5fMfLwayihK3RdRGYrMciBLgLX0Z7g6elqa0CIf5CjVr/Gxw=="],
 
     "@ronin/engine": ["@ronin/engine@0.1.23", "", { "dependencies": { "zod": "3.24.1" } }, "sha512-QDeikl4YEBFHEdful9+x5e8lLrxXvjhubJEYxnFfM7SJoFC9OxoE+Dq4g6mVzRuCI+gN+Odkdy3gd2ARr7eXFg=="],
 
@@ -359,7 +359,7 @@
 
     "rollup": ["rollup@4.39.0", "", { "dependencies": { "@types/estree": "1.0.7" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.39.0", "@rollup/rollup-android-arm64": "4.39.0", "@rollup/rollup-darwin-arm64": "4.39.0", "@rollup/rollup-darwin-x64": "4.39.0", "@rollup/rollup-freebsd-arm64": "4.39.0", "@rollup/rollup-freebsd-x64": "4.39.0", "@rollup/rollup-linux-arm-gnueabihf": "4.39.0", "@rollup/rollup-linux-arm-musleabihf": "4.39.0", "@rollup/rollup-linux-arm64-gnu": "4.39.0", "@rollup/rollup-linux-arm64-musl": "4.39.0", "@rollup/rollup-linux-loongarch64-gnu": "4.39.0", "@rollup/rollup-linux-powerpc64le-gnu": "4.39.0", "@rollup/rollup-linux-riscv64-gnu": "4.39.0", "@rollup/rollup-linux-riscv64-musl": "4.39.0", "@rollup/rollup-linux-s390x-gnu": "4.39.0", "@rollup/rollup-linux-x64-gnu": "4.39.0", "@rollup/rollup-linux-x64-musl": "4.39.0", "@rollup/rollup-win32-arm64-msvc": "4.39.0", "@rollup/rollup-win32-ia32-msvc": "4.39.0", "@rollup/rollup-win32-x64-msvc": "4.39.0", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-thI8kNc02yNvnmJp8dr3fNWJ9tCONDhp6TV35X6HkKGGs9E6q7YWCHbe5vKiTa7TAiNcFEmXKj3X/pG2b3ci0g=="],
 
-    "ronin": ["ronin@6.4.11", "", { "dependencies": { "@ronin/cli": "0.3.2", "@ronin/compiler": "0.17.22", "@ronin/syntax": "0.2.37" }, "bin": { "ronin": "dist/bin/index.js" } }, "sha512-sMg6aHPSjkr0/+efZUBOhihLQFiwasBNIddfI5LDrHDXV1Bu8EAX9h6xqz7Ilio6Sg/x+6w+ksc/Nt4m9kbj1A=="],
+    "ronin": ["ronin@6.4.12", "", { "dependencies": { "@ronin/cli": "0.3.2", "@ronin/compiler": "0.18.0", "@ronin/syntax": "0.2.37" }, "bin": { "ronin": "dist/bin/index.js" } }, "sha512-WsOejY8lWWb0rlojrrXSIWSscJ2OfGgTO2yh4Fj7F5oPr4fR57MYa3Nxm66OMfgl6270mo1C/FjzM9YvHCobvg=="],
 
     "run-applescript": ["run-applescript@7.0.0", "", {}, "sha512-9by4Ij99JUr/MCFBUkDKLWK3G9HVXmabKz9U5MlIAIuvuzkiOicRYs8XJLxX+xahD+mLiiCYDqF9dKAgtzKP1A=="],
 

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@types/bun": "1.2.1",
     "@types/ini": "4.1.1",
     "bun-bagel": "1.1.0",
-    "ronin": "6.4.11",
+    "ronin": "6.4.12",
     "tsup": "8.3.6",
     "typescript": "5.7.3"
   }

--- a/src/utils/model.ts
+++ b/src/utils/model.ts
@@ -31,7 +31,7 @@ export const getModels = async (
   isLocal = true,
 ): Promise<Array<Model>> => {
   const { Transaction } = packages.compiler;
-  const transaction = new Transaction([{ get: { models: null } }]);
+  const transaction = new Transaction([{ list: { models: null } }]);
 
   let rawResults: Array<Array<Row>>;
 


### PR DESCRIPTION
This change makes it possible to use the slug "model" when defining models. For example, a modeling agency might want to do that in order to define the list of people they work with.

As a result, the `get.models()` query was changed to `list.models()`, in order to complete the separation of DDL (Data Definition Language) queries from DML (Data Manipulation Language) queries.

Additionally, a new `list.model('...')` query was added for retrieving a model with a specific slug. This is necessary in order for us to be able to diff two models using queries (before & after). The `list` query type will likely evolve further in the future, just like `create`, `alter`, and `drop` (of course "listing" a single model is not entirely logical).

Originally, the change was landed in https://github.com/ronin-co/compiler/pull/168.