### PR TITLE
Remove stale `@ronin-types` code

### DIFF
--- a/src/commands/apply.ts
+++ b/src/commands/apply.ts
@@ -58,7 +58,7 @@ export default async (
         (await select({
           message: 'Which migration do you want to apply?',
           choices: migrations
-            // Sort in reverse lexical order
+            // Sort in reverse lexical order.
             .sort((a, b) => b.localeCompare(a))
             .map((migration) => ({
               name: migration,
@@ -86,7 +86,7 @@ export default async (
 
     spinner.succeed('Successfully applied migration');
 
-    // If desired, generate new TypeScript types
+    // If desired, generate new TypeScript types.
     if (!flags['skip-types']) await types(appToken, sessionToken);
 
     process.exit(0);

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -2,13 +2,14 @@ import childProcess from 'node:child_process';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import util from 'node:util';
-import types from '@/src/commands/types';
 import ora from 'ora';
 
+import types from '@/src/commands/types';
 import { exists } from '@/src/utils/file';
 import { MIGRATIONS_PATH, MODEL_IN_CODE_PATH, getLocalPackages } from '@/src/utils/misc';
 import { getModels } from '@/src/utils/model';
 import { getOrSelectSpaceId } from '@/src/utils/space';
+
 export const exec = util.promisify(childProcess.exec);
 
 export default async (
@@ -44,8 +45,8 @@ export default async (
 
     const packages = await getLocalPackages();
 
-    // This case should never happen, since we login before running the init command
-    // if no tokens are provided.
+    // This case should never happen, since we log in before
+    // running the init command if no tokens are provided.
     if (!(token?.appToken || token?.sessionToken)) {
       spinner.fail(
         'Run `ronin login` to authenticate with RONIN or provide an app token',
@@ -67,7 +68,7 @@ export default async (
       await types(token.appToken, token.sessionToken);
     }
 
-    // Create ronin directories if they don't exist.
+    // Create migration directory if it doesn't exist.
     if (!(await exists(MIGRATIONS_PATH))) {
       await fs.mkdir(MIGRATIONS_PATH, { recursive: true });
     }

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -2,23 +2,25 @@ import childProcess from 'node:child_process';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import util from 'node:util';
-import json5 from 'json5';
+import types from '@/src/commands/types';
 import ora from 'ora';
 
 import { exists } from '@/src/utils/file';
 import { MIGRATIONS_PATH, MODEL_IN_CODE_PATH, getLocalPackages } from '@/src/utils/misc';
 import { getModels } from '@/src/utils/model';
-
+import { getOrSelectSpaceId } from '@/src/utils/space';
 export const exec = util.promisify(childProcess.exec);
 
-export default async (positionals: Array<string>): Promise<void> => {
+export default async (
+  positionals: Array<string>,
+  token?: { appToken?: string; sessionToken?: string },
+): Promise<void> => {
   const spinner = ora('Initializing project').start();
   const lastPositional = positionals.at(-1);
-  const spaceHandle = lastPositional === 'init' ? null : lastPositional;
+  let spaceHandle = lastPositional === 'init' ? null : lastPositional;
 
   if (!spaceHandle) {
-    spinner.fail('Please provide a space handle like this:\n$ ronin init my-space');
-    process.exit(1);
+    spaceHandle = await getOrSelectSpaceId(token?.sessionToken, spinner);
   }
 
   if (!(await exists('package.json'))) {
@@ -28,11 +30,6 @@ export default async (positionals: Array<string>): Promise<void> => {
     process.exit(1);
   }
 
-  const packageManager = (await exists('bun.lockb')) ? 'bun' : 'npm';
-  const packageManagerName = packageManager === 'bun' ? 'Bun' : 'npm';
-
-  spinner.text = `Detected ${packageManagerName} — installing types package`;
-
   try {
     // Add `.ronin` to `.gitignore` if `.gitignore` exists but doesn't contain `.ronin`.
     const gitignoreExists = await exists('.gitignore');
@@ -40,47 +37,52 @@ export default async (positionals: Array<string>): Promise<void> => {
     if (gitignoreExists) {
       const gitignorePath = path.join(process.cwd(), '.gitignore');
       const gitignoreContents = await fs.readFile(gitignorePath, 'utf-8');
+
       if (!gitignoreContents.includes('.ronin')) {
         await fs.appendFile(gitignorePath, '\n.ronin');
       }
     }
 
     const packages = await getLocalPackages();
-    const doModelsExist = (await getModels(packages)).length > 0;
+
+    if (!(token?.appToken || token?.sessionToken)) {
+      spinner.fail(
+        'Run `ronin login` to authenticate with RONIN or provide an app token',
+      );
+      process.exit(1);
+    }
+
+    const doModelsExist =
+      (
+        await getModels(
+          packages,
+          undefined,
+          token.appToken || token.sessionToken,
+          spaceHandle,
+        )
+      ).length > 0;
 
     if (doModelsExist) {
-      // Install the types package using the preferred package manager.
-      if (packageManager === 'bun') {
-        await exec(`bun add @ronin-types/${spaceHandle} --dev`);
-      } else {
-        await exec(`npm install @ronin-types/${spaceHandle} --save-dev`);
-      }
-    } else {
-      // Create ronin directories.
-      await fs.mkdir(MIGRATIONS_PATH, { recursive: true });
+      await types(token.appToken, token.sessionToken);
+    }
 
-      // Create a `schema/index.ts` file.
+    // Create ronin directories if they don't exist
+    if (!(await exists(MIGRATIONS_PATH))) {
+      await fs.mkdir(MIGRATIONS_PATH, { recursive: true });
+    }
+
+    // Create a `schema/index.ts` file if it doesn't exist
+    if (!(await exists(MODEL_IN_CODE_PATH))) {
+      // Ensure the parent directory exists.
+      const parentDir = path.dirname(MODEL_IN_CODE_PATH);
+      if (!(await exists(parentDir))) {
+        await fs.mkdir(parentDir, { recursive: true });
+      }
       await fs.writeFile(
         MODEL_IN_CODE_PATH,
         '// This file is the starting point to define your models in code.\n',
       );
     }
-
-    // Add the types package to the project's TypeScript config if one exists
-    const tsConfigPath = path.join(process.cwd(), 'tsconfig.json');
-    const tsConfigExists = await exists('tsconfig.json');
-
-    if (!tsConfigExists) return;
-
-    const contents = await fs.readFile(tsConfigPath, 'utf-8');
-    const tsConfig = json5.parse(contents);
-
-    if (!tsConfig.compilerOptions.types?.includes(`@ronin-types/${spaceHandle}`))
-      Object.assign(tsConfig.compilerOptions, {
-        types: [...(tsConfig.compilerOptions.types || []), `@ronin-types/${spaceHandle}`],
-      });
-
-    await fs.writeFile(tsConfigPath, JSON.stringify(tsConfig, null, 2));
   } catch (err) {
     if (err instanceof Error && err.message.includes('401')) {
       spinner.fail(
@@ -88,6 +90,7 @@ export default async (positionals: Array<string>): Promise<void> => {
       );
       process.exit(1);
     }
+    throw err;
   }
 
   spinner.succeed('Project initialized');

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -45,6 +45,8 @@ export default async (
 
     const packages = await getLocalPackages();
 
+    // This case should never happen, since we login before running the init command
+    // if no tokens are provided.
     if (!(token?.appToken || token?.sessionToken)) {
       spinner.fail(
         'Run `ronin login` to authenticate with RONIN or provide an app token',

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -37,7 +37,6 @@ export default async (
     if (gitignoreExists) {
       const gitignorePath = path.join(process.cwd(), '.gitignore');
       const gitignoreContents = await fs.readFile(gitignorePath, 'utf-8');
-
       if (!gitignoreContents.includes('.ronin')) {
         await fs.appendFile(gitignorePath, '\n.ronin');
       }
@@ -68,12 +67,12 @@ export default async (
       await types(token.appToken, token.sessionToken);
     }
 
-    // Create ronin directories if they don't exist
+    // Create ronin directories if they don't exist.
     if (!(await exists(MIGRATIONS_PATH))) {
       await fs.mkdir(MIGRATIONS_PATH, { recursive: true });
     }
 
-    // Create a `schema/index.ts` file if it doesn't exist
+    // Create a `schema/index.ts` file if it doesn't exist.
     if (!(await exists(MODEL_IN_CODE_PATH))) {
       // Ensure the parent directory exists.
       const parentDir = path.dirname(MODEL_IN_CODE_PATH);

--- a/src/commands/types.ts
+++ b/src/commands/types.ts
@@ -35,7 +35,6 @@ export default async (
     await fs.writeFile(tsconfigPath, JSON.stringify(tsconfigContents, null, 2));
 
     spinner.succeed('Successfully generated types');
-    process.exit(0);
   } catch (err) {
     const message =
       err instanceof packages.compiler.RoninError

--- a/src/index.ts
+++ b/src/index.ts
@@ -86,7 +86,11 @@ export const run = async (config: { version: string }): Promise<void> => {
   }
 
   // `init` sub command
-  if (normalizedPositionals.includes('init')) return initializeProject(positionals);
+  if (normalizedPositionals.includes('init'))
+    return initializeProject(positionals, {
+      appToken: appToken,
+      sessionToken: session?.token,
+    });
 
   // `diff` sub command
   if (normalizedPositionals.includes('diff')) {

--- a/src/utils/info.ts
+++ b/src/utils/info.ts
@@ -21,7 +21,7 @@ export const printHelp = (): Promise<void> => {
   {bold COMMANDS}
 
       login                               Authenticate with RONIN (run by default for every command)
-      init [space]                        Initialize the TypeScript types for a given space
+      init [space]                        Initialize RONIN project structure
       diff                                Compare the database schema with the local schema and create a patch
       apply                               Apply the most recent patch to the database
       types                               Generates TypeScript types for the database schema

--- a/src/utils/model.ts
+++ b/src/utils/model.ts
@@ -77,7 +77,6 @@ export const getModels = async (
 
   const results = transaction.formatResults<Model>(rawResults, false);
   const models = 'records' in results[0] ? results[0].records : [];
-
   // @ts-expect-error This will work once the types are fixed.
   return models.map((model) => ({
     ...model,

--- a/src/utils/model.ts
+++ b/src/utils/model.ts
@@ -77,6 +77,7 @@ export const getModels = async (
 
   const results = transaction.formatResults<Model>(rawResults, false);
   const models = 'records' in results[0] ? results[0].records : [];
+
   // @ts-expect-error This will work once the types are fixed.
   return models.map((model) => ({
     ...model,

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -408,6 +408,7 @@ describe('CLI', () => {
 
       test('should fail to initialize a project - no token provided', async () => {
         process.argv = ['bun', 'ronin', 'init', 'test-space'];
+        process.stdout.isTTY = true;
 
         spyOn(sessionModule, 'getSession').mockResolvedValue(null);
         // @ts-expect-error This is a mock.

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -14,6 +14,7 @@ import http from 'node:http';
 import path from 'node:path';
 import * as initModule from '@/src/commands/init';
 import * as loginModule from '@/src/commands/login';
+import * as typesModule from '@/src/commands/types';
 import { run } from '@/src/index';
 import * as infoModule from '@/src/utils/info';
 import * as miscModule from '@/src/utils/misc';
@@ -21,11 +22,10 @@ import * as modelModule from '@/src/utils/model';
 import { convertObjectToArray } from '@/src/utils/model';
 import * as sessionModule from '@/src/utils/session';
 import * as spaceModule from '@/src/utils/space';
-import * as selectModule from '@inquirer/prompts';
 import * as confirmModule from '@inquirer/prompts';
+import * as selectModule from '@inquirer/prompts';
 import * as getPort from 'get-port';
 import * as open from 'open';
-
 describe('CLI', () => {
   // Store original values
   const originalIsTTY = process.stdout.isTTY;
@@ -283,40 +283,43 @@ describe('CLI', () => {
       test('should fail if no space handle is provided', async () => {
         process.argv = ['bun', 'ronin', 'init'];
 
-        try {
-          await run({ version: '1.0.0' });
-        } catch (error) {
-          expect((error as Error).message).toBe('process.exit called');
-          expect(exitSpy).toHaveBeenCalledWith(1);
-          expect(
-            stderrSpy.mock.calls.some((call) => call[0] === 'Initializing project'),
-          ).toBe(true);
-          expect(
-            stderrSpy.mock.calls.some(
-              (call) =>
-                typeof call[0] === 'string' &&
-                call[0].includes('Please provide a space handle like this:'),
-            ),
-          ).toBe(true);
-        }
+        // @ts-expect-error This is a mock.
+        spyOn(spaceModule, 'getOrSelectSpaceId').mockReturnValue('spa_space');
+        // @ts-expect-error This is a mock.
+        spyOn(modelModule, 'getModels').mockReturnValue([{ slug: 'test' }]);
+        // @ts-expect-error This is a mock.
+        spyOn(typesModule, 'default').mockImplementation(() => {});
+
+        await run({ version: '1.0.0' });
+
+        expect(
+          // @ts-expect-error This is a mock.
+          stderrSpy.mock.calls.some((call) => call[0].includes('Project initialized')),
+        ).toBe(true);
       });
 
       test('should fail if no package.json is found', async () => {
         process.argv = ['bun', 'ronin', 'init', 'my-space'];
         spyOn(fs.promises, 'access').mockImplementation(() => Promise.reject());
 
+        spyOn(process, 'exit').mockImplementation(() => {
+          throw new Error('process.exit called');
+        });
+
         try {
           await run({ version: '1.0.0' });
         } catch (error) {
-          expect((error as Error).message).toBe('process.exit called');
-          expect(exitSpy).toHaveBeenCalledWith(1);
           expect(
             stderrSpy.mock.calls.some(
               (call) =>
                 typeof call[0] === 'string' &&
-                call[0].includes('No `package.json` found'),
+                call[0].includes(
+                  'No `package.json` found in the current directory. Please run the command in your project.',
+                ),
             ),
           ).toBe(true);
+          expect((error as Error).message).toBe('process.exit called');
+          expect(exitSpy).toHaveBeenCalledWith(1);
         }
       });
 
@@ -353,23 +356,7 @@ describe('CLI', () => {
         );
       };
 
-      test('should successfully initialize a project with Bun when models exist', async () => {
-        spyOn(modelModule, 'getModels').mockResolvedValue([
-          {
-            slug: 'user',
-            // @ts-expect-error This is a mock.
-            fields: [{ type: 'string', slug: 'name' }],
-          },
-        ]);
-
-        setupInitTest(true);
-        await run({ version: '1.0.0' });
-        expect(initModule.exec).toHaveBeenCalledWith(
-          'bun add @ronin-types/test-space --dev',
-        );
-      });
-
-      test('should successfully initialize a project with Bun when no models exist', async () => {
+      test('should successfully initialize a project when no models exist', async () => {
         spyOn(modelModule, 'getModels').mockResolvedValue([]);
 
         setupInitTest(true);
@@ -384,39 +371,32 @@ describe('CLI', () => {
         );
       });
 
-      test('should successfully initialize a project with npm', async () => {
-        spyOn(modelModule, 'getModels').mockResolvedValue([
-          {
-            slug: 'user',
-            // @ts-expect-error This is a mock.
-            fields: [{ type: 'string', slug: 'name' }],
-          },
-        ]);
-
-        setupInitTest(false);
-        await run({ version: '1.0.0' });
-        expect(initModule.exec).toHaveBeenCalledWith(
-          'npm install @ronin-types/test-space --save-dev',
-        );
-      });
-
       test('should fail to initialize a project with unauthorized access', async () => {
-        spyOn(modelModule, 'getModels').mockResolvedValue([
-          {
-            slug: 'user',
-            // @ts-expect-error This is a mock.
-            fields: [{ type: 'string', slug: 'name' }],
-          },
-        ]);
+        process.argv = ['bun', 'ronin', 'init', 'test-space'];
+
+        spyOn(spaceModule, 'getOrSelectSpaceId').mockResolvedValue('test-space');
+        // Skip types generation.
+        // @ts-expect-error This is a mock.
+        spyOn(typesModule, 'default').mockImplementation(() => {});
 
         setupInitTest();
 
-        // Mock exec to throw unauthorized error
-        spyOn(initModule, 'exec').mockImplementation(() => {
+        spyOn(modelModule, 'getModels').mockImplementation(() => {
           throw new Error('401 Unauthorized');
         });
 
-        await run({ version: '1.0.0' });
+        spyOn(process, 'exit').mockImplementation(() => {
+          throw new Error('process.exit called');
+        });
+
+        try {
+          await run({ version: '1.0.0' });
+        } catch (error) {
+          expect(error).toBeInstanceOf(Error);
+          expect((error as Error).message).toContain('process.exit called');
+          expect(exitSpy).toHaveBeenCalledWith(1);
+        }
+
         expect(
           stderrSpy.mock.calls.some(
             (call) =>

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -406,6 +406,44 @@ describe('CLI', () => {
         ).toBe(true);
       });
 
+      test('should fail to initialize a project - no token provided', async () => {
+        process.argv = ['bun', 'ronin', 'init', 'test-space'];
+
+        spyOn(sessionModule, 'getSession').mockResolvedValue(null);
+        // @ts-expect-error This is a mock.
+        spyOn(loginModule, 'default').mockImplementation(() => Promise.resolve());
+
+        spyOn(process, 'exit').mockImplementation(() => {
+          throw new Error('process.exit called');
+        });
+
+        setupInitTest();
+
+        spyOn(process, 'exit').mockImplementation(() => {
+          throw new Error('process.exit called');
+        });
+
+        try {
+          await run({ version: '1.0.0' });
+        } catch (error) {
+          expect(error).toBeInstanceOf(Error);
+          expect((error as Error).message).toContain('process.exit called');
+          expect(exitSpy).toHaveBeenCalledWith(1);
+        }
+
+        console.error(stderrSpy.mock.calls);
+
+        expect(
+          stderrSpy.mock.calls.some(
+            (call) =>
+              typeof call[0] === 'string' &&
+              call[0].includes(
+                'Run `ronin login` to authenticate with RONIN or provide an app token',
+              ),
+          ),
+        ).toBe(true);
+      });
+
       test('diff and apply', async () => {
         process.argv = ['bun', 'ronin', 'diff', '--apply'];
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -26,6 +26,7 @@ import * as confirmModule from '@inquirer/prompts';
 import * as selectModule from '@inquirer/prompts';
 import * as getPort from 'get-port';
 import * as open from 'open';
+
 describe('CLI', () => {
   // Store original values
   const originalIsTTY = process.stdout.isTTY;

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -49,14 +49,4 @@ describe('CLI Integration Tests', () => {
     expect(exitCode).toBe(0);
     expect(stdout.toString()).toMatch(/\d+\.\d+\.\d+/); // Matches semver format
   });
-
-  test('should fail init command without space handle', async () => {
-    const { stderr, exitCode } = await $`RONIN_TOKEN=test bun ${CLI_PATH} init`
-      .nothrow()
-      .quiet();
-
-    expect(exitCode).toBe(1);
-    expect(stderr.toString()).toContain('Please provide a space handle like this:');
-    expect(stderr.toString()).toContain('$ ronin init my-space');
-  });
 });


### PR DESCRIPTION
The `ronin init` command was experiencing issues with getting stuck during execution. In this update, we have resolved that problem. Additionally, we have cleaned up the codebase by removing a significant amount of unnecessary code, improving overall efficiency and maintainability.

