### PR TITLE
Allow for updating `idPrefix` and fields

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -22,7 +22,7 @@
         "@types/bun": "1.2.1",
         "@types/ini": "4.1.1",
         "bun-bagel": "1.1.0",
-        "ronin": "6.4.12",
+        "ronin": "6.4.18",
         "tsup": "8.3.6",
         "typescript": "5.7.3",
       },
@@ -185,9 +185,9 @@
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.40.0", "", { "os": "win32", "cpu": "x64" }, "sha512-lpPE1cLfP5oPzVjKMx10pgBmKELQnFJXHgvtHCtuJWOv8MxqdEIMNtgHgBFf7Ea2/7EuVwa9fodWUfXAlXZLZQ=="],
 
-    "@ronin/cli": ["@ronin/cli@0.3.2", "", { "dependencies": { "@dprint/formatter": "0.4.1", "@dprint/typescript": "0.93.3", "@iarna/toml": "2.2.5", "@inquirer/prompts": "7.2.3", "@ronin/engine": "0.1.16", "chalk-template": "1.1.0", "get-port": "7.1.0", "ini": "5.0.0", "json5": "2.2.3", "open": "10.1.0", "ora": "8.1.1", "resolve-from": "5.0.0" } }, "sha512-CBSDhRtd7BkRd4JO5s4b/AUXkw75nnUiV8LSKwNQxcYZFlcEWbr5xWfnxF1zP3Iv1uGpZTvzCI6naeAePSGmZA=="],
+    "@ronin/cli": ["@ronin/cli@0.3.5", "", { "dependencies": { "@dprint/formatter": "0.4.1", "@dprint/typescript": "0.93.3", "@iarna/toml": "2.2.5", "@inquirer/prompts": "7.2.3", "@ronin/engine": "0.1.23", "chalk-template": "1.1.0", "get-port": "7.1.0", "ini": "5.0.0", "json5": "2.2.3", "open": "10.1.0", "ora": "8.1.1", "resolve-from": "5.0.0" } }, "sha512-mrHRpEfUSnTaifvdGJClCo2Nf6OwxwOcJ/ZABx65YHeihkuE6sUNBy7zaCWCea4jZkFvQW/vlcOUrDtzBxz2xg=="],
 
-    "@ronin/compiler": ["@ronin/compiler@0.18.0", "", {}, "sha512-r6s90ylJWwpTJdJ+GOwku2DOaelgKJTn90RGSr5fMfLwayihK3RdRGYrMciBLgLX0Z7g6elqa0CIf5CjVr/Gxw=="],
+    "@ronin/compiler": ["@ronin/compiler@0.18.1", "", {}, "sha512-hCxs8prvHx98nP4Z3VZT0D6IPKL6adakruq2k3BjxNRYtS/r2EfRhrbEI/V3+L7WbYGH2A9FO0brr3/HUgj7wQ=="],
 
     "@ronin/engine": ["@ronin/engine@0.1.23", "", { "dependencies": { "zod": "3.24.1" } }, "sha512-QDeikl4YEBFHEdful9+x5e8lLrxXvjhubJEYxnFfM7SJoFC9OxoE+Dq4g6mVzRuCI+gN+Odkdy3gd2ARr7eXFg=="],
 
@@ -359,7 +359,7 @@
 
     "rollup": ["rollup@4.40.0", "", { "dependencies": { "@types/estree": "1.0.7" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.40.0", "@rollup/rollup-android-arm64": "4.40.0", "@rollup/rollup-darwin-arm64": "4.40.0", "@rollup/rollup-darwin-x64": "4.40.0", "@rollup/rollup-freebsd-arm64": "4.40.0", "@rollup/rollup-freebsd-x64": "4.40.0", "@rollup/rollup-linux-arm-gnueabihf": "4.40.0", "@rollup/rollup-linux-arm-musleabihf": "4.40.0", "@rollup/rollup-linux-arm64-gnu": "4.40.0", "@rollup/rollup-linux-arm64-musl": "4.40.0", "@rollup/rollup-linux-loongarch64-gnu": "4.40.0", "@rollup/rollup-linux-powerpc64le-gnu": "4.40.0", "@rollup/rollup-linux-riscv64-gnu": "4.40.0", "@rollup/rollup-linux-riscv64-musl": "4.40.0", "@rollup/rollup-linux-s390x-gnu": "4.40.0", "@rollup/rollup-linux-x64-gnu": "4.40.0", "@rollup/rollup-linux-x64-musl": "4.40.0", "@rollup/rollup-win32-arm64-msvc": "4.40.0", "@rollup/rollup-win32-ia32-msvc": "4.40.0", "@rollup/rollup-win32-x64-msvc": "4.40.0", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-Noe455xmA96nnqH5piFtLobsGbCij7Tu+tb3c1vYjNbTkfzGqXqQXG3wJaYXkRZuQ0vEYN4bhwg7QnIrqB5B+w=="],
 
-    "ronin": ["ronin@6.4.12", "", { "dependencies": { "@ronin/cli": "0.3.2", "@ronin/compiler": "0.18.0", "@ronin/syntax": "0.2.37" }, "bin": { "ronin": "dist/bin/index.js" } }, "sha512-WsOejY8lWWb0rlojrrXSIWSscJ2OfGgTO2yh4Fj7F5oPr4fR57MYa3Nxm66OMfgl6270mo1C/FjzM9YvHCobvg=="],
+    "ronin": ["ronin@6.4.18", "", { "dependencies": { "@ronin/cli": "0.3.5", "@ronin/compiler": "0.18.1", "@ronin/syntax": "0.2.37" }, "bin": { "ronin": "dist/bin/index.js" } }, "sha512-l5LklseGLMN44E2FMW6GkK6nER+A+wQQBec5cmtWTJwboM4OPmriNBAB+i8zj/KRLPj2MozG214kfFj4A1h5Zw=="],
 
     "run-applescript": ["run-applescript@7.0.0", "", {}, "sha512-9by4Ij99JUr/MCFBUkDKLWK3G9HVXmabKz9U5MlIAIuvuzkiOicRYs8XJLxX+xahD+mLiiCYDqF9dKAgtzKP1A=="],
 
@@ -426,8 +426,6 @@
     "@isaacs/cliui/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
 
     "@isaacs/cliui/wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
-
-    "@ronin/cli/@ronin/engine": ["@ronin/engine@0.1.16", "", { "dependencies": { "zod": "3.24.1" } }, "sha512-u1+MNPhj5XtLLCXcDNq6dlcYyb0B/VHndyZOJzFWPEXIIWj5ULdAHJ04VT/Gvmjxb3UlBN0EZIgA1ycNL8H5+w=="],
 
     "log-symbols/is-unicode-supported": ["is-unicode-supported@1.3.0", "", {}, "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ=="],
 

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@types/bun": "1.2.1",
     "@types/ini": "4.1.1",
     "bun-bagel": "1.1.0",
-    "ronin": "6.4.12",
+    "ronin": "6.4.18",
     "tsup": "8.3.6",
     "typescript": "5.7.3"
   }

--- a/src/commands/diff.ts
+++ b/src/commands/diff.ts
@@ -84,11 +84,13 @@ export default async (
         if (
           JSON.stringify(currentMigrationDiff) === JSON.stringify(latestMigrationDiff)
         ) {
+          spinner.stop();
           const shouldProceed = await confirm({
             message:
               'The current changes are identical to the latest migration. Do you want to create another migration anyway?',
             default: false,
           });
+          spinner.start();
 
           if (!shouldProceed) {
             spinner.succeed('Migration creation cancelled');

--- a/src/utils/migration.ts
+++ b/src/utils/migration.ts
@@ -281,8 +281,8 @@ export const adjustModelMeta = (
     // All records inserted will use the new prefix. All old ids are not updated.
     queries.push(
       ...createTempModelQuery(
-        // Use the updated model meta properties and the fields from the existing model,
-        // because we want to only update the model meta properties and add the fields afterwards.
+        // Create a temporary model with the new `idPrefix` but keep the existing fields.
+        // We later on drop, add or modify the fields.
         convertModelToObjectFields({ ...definedModel, fields: existingModel.fields }),
         {
           name: existingModel.name,
@@ -290,10 +290,7 @@ export const adjustModelMeta = (
         },
       ),
     );
-    // The model name only exists in the `ronin_schema` table, thus it does not need to
-    // recreate the SQL table.
   } else if (definedModel.name && definedModel.name !== existingModel.name) {
-    // Otherwise, just update the name.
     queries.push(
       `alter.model("${definedModel.slug}").to({name: "${definedModel.name}"})`,
     );
@@ -303,7 +300,7 @@ export const adjustModelMeta = (
 };
 
 /**
- * Generates queries to adjust metadata like name and ID prefix for multiple models.
+ * Generates queries to adjust metadata like `name` and `idPrefix` for multiple models.
  *
  * @param definedModels - The models defined locally.
  * @param existingModels - The models currently defined in the database.

--- a/src/utils/migration.ts
+++ b/src/utils/migration.ts
@@ -278,7 +278,7 @@ export const adjustModelMeta = (
   // the model.
   if (definedModel.idPrefix && definedModel.idPrefix !== existingModel.idPrefix) {
     // If the prefix changes we need to recreate the model.
-    // All records inserted will use the new prefix. All old ids are not updated.
+    // All records inserted will use the new prefix. All old IDs are not updated.
     queries.push(
       ...createTempModelQuery(
         // Create a temporary model with the new `idPrefix` but keep the existing fields.

--- a/tests/fixtures/utils.ts
+++ b/tests/fixtures/utils.ts
@@ -97,7 +97,6 @@ export const runMigration = async (
   const packages = await getLocalPackages();
   const models = await getModels(packages, db);
   const modelDiff = await diffModels(definedModels, models, options);
-
   const protocol = new Protocol(packages, modelDiff);
   await protocol.convertToQueryObjects();
 

--- a/tests/utils/apply.test.ts
+++ b/tests/utils/apply.test.ts
@@ -472,6 +472,60 @@ describe('apply', () => {
           expect(rows[0].id).toContain('corny_');
           expect(rows[1].id).toContain('test_');
         });
+
+        test('id prefix and add fields', async () => {
+          const definedModel = model({
+            slug: 'test',
+            idPrefix: 'test',
+            fields: {
+              name: string(),
+              age: number(),
+              email: string(),
+            },
+          }) as unknown as Model;
+
+          const existingModel = model({
+            slug: 'test',
+            idPrefix: 'corny',
+            fields: {
+              name: string(),
+            },
+          }) as unknown as Model;
+
+          const insert = {
+            add: {
+              test: {
+                with: {
+                  name: 'Ilayda',
+                },
+              },
+            },
+          };
+
+          const transaction = new Transaction([insert], {
+            // @ts-expect-error This works once the types are fixed.
+            models: [definedModel, existingModel],
+            inlineParams: true,
+          });
+
+          const { db, models, modelDiff } = await runMigration(
+            // @ts-expect-error This works once the types are fixed.
+            [definedModel],
+            [existingModel],
+            {},
+            transaction.statements.map((statement) => statement),
+          );
+
+          await db.query(transaction.statements);
+          const rows = await getTableRows(db, models[0]);
+
+          expect(modelDiff).toHaveLength(6);
+          expect(models[0].slug).toBe('test');
+          expect(models[0].name).toBe('Test');
+          expect(models[0].pluralName).toBe('Tests');
+          expect(rows[0].id).toContain('corny_');
+          expect(rows[1].id).toContain('test_');
+        });
       });
     });
   });

--- a/tests/utils/apply.test.ts
+++ b/tests/utils/apply.test.ts
@@ -582,6 +582,118 @@ describe('apply', () => {
           expect(rows[0].id).toContain('corny_');
           expect(rows[1].id).toContain('test_');
         });
+
+        test('id prefix and adjust field', async () => {
+          const definedModel = model({
+            slug: 'test',
+            idPrefix: 'test',
+            fields: {
+              name: string({ defaultValue: 'I <3 RONIN' }),
+            },
+          }) as unknown as Model;
+
+          const existingModel = model({
+            slug: 'test',
+            idPrefix: 'corny',
+            fields: {
+              name: string(),
+            },
+          }) as unknown as Model;
+
+          const insert = {
+            add: {
+              test: {
+                with: {
+                  name: 'Ilayda',
+                },
+              },
+            },
+          };
+
+          const transaction = new Transaction([insert], {
+            // @ts-expect-error This works once the types are fixed.
+            models: [definedModel, existingModel],
+            inlineParams: true,
+          });
+
+          const { db, models, modelDiff } = await runMigration(
+            // @ts-expect-error This works once the types are fixed.
+            [definedModel],
+            [existingModel],
+            {},
+            transaction.statements.map((statement) => statement),
+          );
+
+          await db.query(transaction.statements);
+          const rows = await getTableRows(db, models[0]);
+
+          console.error(modelDiff);
+
+          expect(models[0].fields).toHaveLength(1);
+          expect(modelDiff).toHaveLength(8);
+          expect(models[0].slug).toBe('test');
+          expect(models[0].name).toBe('Test');
+          expect(models[0].pluralName).toBe('Tests');
+          expect(rows[0].id).toContain('corny_');
+          expect(rows[1].id).toContain('test_');
+        });
+
+        test('id prefix and drop, add and adjust fields', async () => {
+          const definedModel = model({
+            slug: 'test',
+            idPrefix: 'test',
+            fields: {
+              name: string({ defaultValue: 'I <3 RONIN' }),
+              email: string(),
+            },
+          }) as unknown as Model;
+
+          const existingModel = model({
+            slug: 'test',
+            idPrefix: 'corny',
+            fields: {
+              name: string(),
+              age: number(),
+            },
+          }) as unknown as Model;
+
+          const insert = {
+            add: {
+              test: {
+                with: {
+                  name: 'Ilayda',
+                },
+              },
+            },
+          };
+
+          const transaction = new Transaction([insert], {
+            // @ts-expect-error This works once the types are fixed.
+            models: [definedModel, existingModel],
+            inlineParams: true,
+          });
+
+          const { db, models, modelDiff } = await runMigration(
+            // @ts-expect-error This works once the types are fixed.
+            [definedModel],
+            [existingModel],
+            {},
+            transaction.statements.map((statement) => statement),
+          );
+
+          await db.query(transaction.statements);
+          const rows = await getTableRows(db, models[0]);
+
+          console.error(modelDiff);
+
+          expect(models[0].fields).toHaveLength(2);
+          expect(modelDiff).toHaveLength(10);
+          expect(models[0].slug).toBe('test');
+          expect(models[0].name).toBe('Test');
+          expect(models[0].pluralName).toBe('Tests');
+          expect(rows[0].id).toContain('corny_');
+          expect(rows[1].id).toContain('test_');
+        });
       });
     });
   });

--- a/tests/utils/migration.test.ts
+++ b/tests/utils/migration.test.ts
@@ -11,7 +11,7 @@ import {
   TestE,
 } from '@/fixtures/index';
 import {
-  adjustModelMeta,
+  adjustModelsMeta,
   createModels,
   diffModels,
   dropModels,
@@ -396,7 +396,7 @@ describe('migration', () => {
         },
       ];
 
-      const queries = adjustModelMeta(definedModels, existingModels);
+      const queries = adjustModelsMeta(definedModels, existingModels);
 
       expect(queries).toHaveLength(8);
       expect(queries).toStrictEqual([
@@ -434,7 +434,7 @@ describe('migration', () => {
         },
       ];
 
-      const queries = adjustModelMeta(definedModels, existingModels);
+      const queries = adjustModelsMeta(definedModels, existingModels);
 
       expect(queries).toHaveLength(1);
       expect(queries).toStrictEqual(['alter.model("test1").to({name: "Test Model 1"})']);
@@ -457,7 +457,7 @@ describe('migration', () => {
         },
       ];
 
-      const queries = adjustModelMeta(definedModels, existingModels);
+      const queries = adjustModelsMeta(definedModels, existingModels);
 
       expect(queries).toHaveLength(0);
       expect(queries).toStrictEqual([]);


### PR DESCRIPTION
This pull request resolves an issue where modifying the `idPrefix` results in a temporary table being created with the fields from the models in code. This leads to the migration process generating `create` and `drop` queries for these fields, causing errors because the fields either already exist or have been removed.