### PR TITLE
Support for `pnpm`

### DIFF
--- a/src/utils/misc.ts
+++ b/src/utils/misc.ts
@@ -416,15 +416,21 @@ const getPackage = <Name extends 'syntax/queries' | 'compiler'>(
 ): Promise<
   Name extends 'syntax/queries' ? LocalPackages['syntax'] : LocalPackages['compiler']
 > => {
-  const roninSyntaxPath = resolveFrom.silent(process.cwd(), `@ronin/${name}`);
+  try {
+    // First try direct import which works with pnpm.
+    return import(`@ronin/${name}`);
+  } catch {
+    // Fallback to resolveFrom for bun/npm/yarn.
+    const roninSyntaxPath = resolveFrom.silent(process.cwd(), `@ronin/${name}`);
 
-  if (!roninSyntaxPath) {
-    throw new Error(
-      'The "ronin" package must be installed in your project in order to create migrations.',
-    );
+    if (!roninSyntaxPath) {
+      throw new Error(
+        'The "ronin" package must be installed in your project in order to create migrations.',
+      );
+    }
+
+    return import(roninSyntaxPath);
   }
-
-  return import(roninSyntaxPath);
 };
 
 /**


### PR DESCRIPTION
The CLI encountered issues when used with projects created using `pnpm`. This problem arises because `pnpm` organizes packages in the `node_modules` directory differently compared to other package managers like `npm`, `bun`, or `yarn`.

