### PR TITLE
Added `ronin pull`

### DIFF
--- a/src/commands/apply.ts
+++ b/src/commands/apply.ts
@@ -27,13 +27,12 @@ export default async (
 
   try {
     const space = await getOrSelectSpaceId(sessionToken, spinner);
-    const existingModels = await getModels(
-      packages,
+    const existingModels = await getModels(packages, {
       db,
-      appToken ?? sessionToken,
+      token: appToken ?? sessionToken,
       space,
-      flags.local,
-    );
+      isLocal: flags.local,
+    });
 
     // Verify that the migrations directory exists before proceeding.
     if (!fs.existsSync(MIGRATIONS_PATH)) {

--- a/src/commands/diff.ts
+++ b/src/commands/diff.ts
@@ -50,7 +50,12 @@ export default async (
     const [existingModels, definedModels] = await Promise.all([
       flags['force-create']
         ? []
-        : getModels(packages, db, appToken ?? sessionToken, space, flags.local),
+        : getModels(packages, {
+            db,
+            token: appToken ?? sessionToken,
+            space,
+            isLocal: flags.local,
+          }),
       flags['force-drop'] ? [] : getModelDefinitions(modelsInCodePath),
     ]);
 

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -56,12 +56,10 @@ export default async (
 
     const doModelsExist =
       (
-        await getModels(
-          packages,
-          undefined,
-          token.appToken || token.sessionToken,
-          spaceHandle,
-        )
+        await getModels(packages, {
+          token: token.appToken || token.sessionToken,
+          space: spaceHandle,
+        })
       ).length > 0;
 
     if (doModelsExist) {

--- a/src/commands/pull.ts
+++ b/src/commands/pull.ts
@@ -1,0 +1,123 @@
+import * as fs from 'node:fs/promises';
+import { confirm } from '@inquirer/prompts';
+
+import { formatCode } from '@/src/utils/format';
+import {
+  type LocalPackages,
+  MODEL_IN_CODE_PATH,
+  getLocalPackages,
+} from '@/src/utils/misc';
+import { getModels } from '@/src/utils/model';
+import { spinner as ora } from '@/src/utils/spinner';
+
+/**
+ * Pulls models from RONIN schema into model definitions file.
+ *
+ * @param appToken - The app token to use.
+ * @param sessionToken - The session token to use.
+ * @param local - Whether to pull models from the local database.
+ */
+export default async (
+  appToken?: string,
+  sessionToken?: string,
+  local?: boolean,
+): Promise<void> => {
+  const spinner = ora.start('Pulling models');
+  const packages = await getLocalPackages();
+
+  try {
+    // Get models from RONIN schema.
+    const modelDefinitions = await getModelDefinitionsFileContent(packages, {
+      appToken,
+      sessionToken,
+      local,
+    });
+
+    if (!modelDefinitions) {
+      spinner.fail('No models found. Start defining models in your code.');
+      process.exit(1);
+    }
+
+    if ((await fs.exists(MODEL_IN_CODE_PATH)) && modelDefinitions) {
+      if (
+        JSON.stringify(modelDefinitions) ===
+        JSON.stringify(await fs.readFile(MODEL_IN_CODE_PATH, 'utf-8'))
+      ) {
+        spinner.succeed('Your model definitions are up to date.');
+        return;
+      }
+
+      spinner.stop();
+      const overwrite = await confirm({
+        message: 'A model definition file already exists. Do you want to overwrite it?',
+      });
+      spinner.start();
+
+      if (!overwrite) {
+        return;
+      }
+    }
+
+    await fs.writeFile(MODEL_IN_CODE_PATH, modelDefinitions);
+    spinner.succeed('Models pulled');
+  } catch {
+    spinner.fail('Failed to pull models');
+    process.exit(1);
+  }
+};
+
+export const getModelDefinitionsFileContent = async (
+  packages: LocalPackages,
+  options?: {
+    appToken?: string;
+    sessionToken?: string;
+    local?: boolean;
+  },
+): Promise<string | null> => {
+  const models = await getModels(packages, {
+    token: options?.appToken || options?.sessionToken,
+    isLocal: options?.local,
+  });
+
+  if (models.length === 0) {
+    return null;
+  }
+
+  const primitives = [
+    ...new Set(models.flatMap((model) => model.fields.map((field) => field.type))),
+  ];
+  const importStatements = `import { model, ${primitives.join(',')} } from "ronin/schema";`;
+
+  const modelDefinitions = models.map((model) => {
+    const { fields, indexes, ...rest } = model;
+
+    const fieldsDefinition = fields
+      .map((field) => {
+        const { slug, type, ...rest } = field;
+
+        return `${slug}: ${type}(${Object.keys(rest).length === 0 ? '' : JSON.stringify(rest)})`;
+      })
+      .join(',\n');
+
+    return `export const ${capitalize(model.slug)} = model({
+        ${JSON.stringify(rest).slice(1, -1)},
+        ${
+          fieldsDefinition
+            ? `fields: {
+            ${fieldsDefinition}
+        },`
+            : ''
+        }
+        ${indexes ? `indexes: ${JSON.stringify(indexes)}` : ''}
+    });`;
+  });
+
+  return formatCode(`${importStatements}
+    
+    ${modelDefinitions.join('\n\n')}
+  `);
+};
+
+const capitalize = (val: string): string => {
+  return String(val).charAt(0).toUpperCase() + String(val).slice(1);
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,9 +5,10 @@ import apply from '@/src/commands/apply';
 import diff from '@/src/commands/diff';
 import initializeProject from '@/src/commands/init';
 import logIn from '@/src/commands/login';
+import pull from '@/src/commands/pull';
 import generateTypes from '@/src/commands/types';
 import { printHelp, printVersion } from '@/src/utils/info';
-import { MIGRATION_FLAGS } from '@/src/utils/migration';
+import { MIGRATION_FLAGS, type MigrationFlags } from '@/src/utils/migration';
 import { BASE_FLAGS, type BaseFlags } from '@/src/utils/misc';
 import { getSession } from '@/src/utils/session';
 import { spinner } from '@/src/utils/spinner';
@@ -109,6 +110,11 @@ export const run = async (config: { version: string }): Promise<void> => {
   // `types` sub command.
   if (normalizedPositionals.includes('types'))
     return generateTypes(appToken, session?.token);
+
+  // `pull` sub command
+  if (normalizedPositionals.includes('pull')) {
+    return pull(appToken, session?.token, (flags as MigrationFlags).local);
+  }
 
   // If no matching flags or commands were found, render the help, since we don't want to
   // use the main `ronin` command for anything yet.

--- a/src/utils/info.ts
+++ b/src/utils/info.ts
@@ -25,6 +25,7 @@ export const printHelp = (): Promise<void> => {
       diff                                Compare the database schema with the local schema and create a patch
       apply                               Apply the most recent patch to the database
       types                               Generates TypeScript types for the database schema
+      pull                                Pull models from RONIN schema into model definitions file
 
   {bold OPTIONS}
 

--- a/src/utils/model.ts
+++ b/src/utils/model.ts
@@ -30,13 +30,16 @@ export type ModelWithFieldsArray = Omit<Model, 'fields'> & { fields: Array<Model
  */
 export const getModels = async (
   packages: LocalPackages,
-  db?: Database,
-  token?: string,
-  space?: string,
-  isLocal = true,
+  options?: {
+    db?: Database;
+    token?: string;
+    space?: string;
+    isLocal?: boolean;
+  },
 ): Promise<Array<ModelWithFieldsArray>> => {
   const { Transaction } = packages.compiler;
   const transaction = new Transaction([{ list: { models: null } }]);
+  const { db, token, space, isLocal = true } = options || {};
 
   let rawResults: Array<Array<Row>>;
 
@@ -73,7 +76,7 @@ export const getModels = async (
         spinner.stop();
         const sessionToken = await logIn(undefined, false);
         spinner.start();
-        return getModels(packages, db, sessionToken, space, isLocal);
+        return getModels(packages, { db, token: sessionToken, space, isLocal });
       }
 
       throw new Error(`Failed to fetch remote models: ${(error as Error).message}`);

--- a/tests/fixtures/utils.ts
+++ b/tests/fixtures/utils.ts
@@ -95,7 +95,7 @@ export const runMigration = async (
   const db = await queryEphemeralDatabase(existingModels, insertStatements);
 
   const packages = await getLocalPackages();
-  const models = await getModels(packages, db);
+  const models = await getModels(packages, { db });
   const modelDiff = await new Migration(
     definedModels,
     models.map((model) => convertModelToObjectFields(model)),
@@ -113,7 +113,7 @@ export const runMigration = async (
   return {
     db,
     packages,
-    models: (await getModels(packages, db)).map((model) =>
+    models: (await getModels(packages, { db })).map((model) =>
       convertModelToObjectFields(model),
     ),
     statements,

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1113,4 +1113,19 @@ describe('CLI', () => {
       ).toBe(true);
     });
   });
+
+  describe('pull', () => {
+    test('pulled model are up to date', async () => {
+      process.argv = ['bun', 'ronin', 'pull'];
+
+      await run({ version: '1.0.0' });
+
+      expect(
+        stderrSpy.mock.calls.some(
+          (call) =>
+            typeof call[0] === 'string' && call[0].includes('Failed to pull models'),
+        ),
+      ).toBe(true);
+    });
+  });
 });

--- a/tests/utils/model.test.ts
+++ b/tests/utils/model.test.ts
@@ -11,7 +11,7 @@ describe('models', async () => {
   describe('local', () => {
     test('get models from local but there are no models', async () => {
       const packages = await getLocalPackages();
-      const models = await getModelsModule.getModels(packages, db);
+      const models = await getModelsModule.getModels(packages, { db });
 
       expect(models).toHaveLength(0);
       expect(models).toStrictEqual([]);
@@ -32,7 +32,7 @@ describe('models', async () => {
        `,
       ]);
 
-      const models = await getModelsModule.getModels(packages, db);
+      const models = await getModelsModule.getModels(packages, { db });
 
       expect(models).toHaveLength(1);
 
@@ -63,13 +63,12 @@ describe('models', async () => {
         method: 'POST',
       });
 
-      const models = await getModelsModule.getModels(
-        packages,
+      const models = await getModelsModule.getModels(packages, {
         db,
-        '',
-        'updated-bsql-ip',
-        false,
-      );
+        token: '',
+        space: 'updated-bsql-ip',
+        isLocal: false,
+      });
 
       expect(models).toStrictEqual([]);
       expect(models).toHaveLength(0);
@@ -92,13 +91,12 @@ describe('models', async () => {
         method: 'POST',
       });
 
-      const models = await getModelsModule.getModels(
-        packages,
+      const models = await getModelsModule.getModels(packages, {
         db,
-        '',
-        'updated-bsql-ip',
-        false,
-      );
+        token: '',
+        space: 'updated-bsql-ip',
+        isLocal: false,
+      });
 
       expect(models).toStrictEqual([]);
       expect(models).toHaveLength(0);
@@ -128,7 +126,12 @@ describe('models', async () => {
       });
 
       try {
-        await getModelsModule.getModels(packages, db, '', 'test', false);
+        await getModelsModule.getModels(packages, {
+          db,
+          token: '',
+          space: 'test',
+          isLocal: false,
+        });
       } catch (err) {
         const error = err as Error;
         expect(error).toBeInstanceOf(Error);

--- a/tests/utils/pull.test.ts
+++ b/tests/utils/pull.test.ts
@@ -1,0 +1,307 @@
+import { afterAll, afterEach, beforeAll, describe, expect, spyOn, test } from 'bun:test';
+import * as fs from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+import pull, { getModelDefinitionsFileContent } from '@/src/commands/pull';
+import { formatCode } from '@/src/utils/format';
+import { MODEL_IN_CODE_PATH, getLocalPackages } from '@/src/utils/misc';
+import * as modelModule from '@/src/utils/model';
+import * as confirmModule from '@inquirer/prompts';
+import { $ } from 'bun';
+
+describe('helper', () => {
+  test('no models', async () => {
+    spyOn(modelModule, 'getModels').mockResolvedValue([]);
+
+    const packages = await getLocalPackages();
+    const models = await getModelDefinitionsFileContent(packages);
+    expect(models).toBeNull();
+  });
+
+  test('one simple model', async () => {
+    spyOn(modelModule, 'getModels').mockResolvedValue([
+      {
+        slug: 'user',
+        name: 'CustomName',
+        fields: [
+          {
+            slug: 'name',
+            type: 'string',
+            required: true,
+          },
+          {
+            slug: 'age',
+            type: 'number',
+          },
+          {
+            slug: 'isActive',
+            type: 'boolean',
+          },
+        ],
+      },
+    ]);
+
+    const packages = await getLocalPackages();
+    const models = await getModelDefinitionsFileContent(packages);
+    expect(models).toBeDefined();
+    expect(models).toBe(
+      formatCode(`import { boolean, model, number, string } from "ronin/schema";
+
+                export const User = model({
+                slug: "user",
+                name: "CustomName",
+                fields: {
+                    name: string({ required: true }),
+                    age: number(),
+                    isActive: boolean(),
+                },
+            });`),
+    );
+  });
+
+  test('two models', async () => {
+    spyOn(modelModule, 'getModels').mockResolvedValue([
+      {
+        slug: 'user',
+        fields: [
+          {
+            slug: 'name',
+            type: 'string',
+            required: true,
+          },
+        ],
+      },
+      {
+        slug: 'post',
+        fields: [{ slug: 'title', type: 'string' }],
+      },
+    ]);
+
+    const packages = await getLocalPackages();
+    const models = await getModelDefinitionsFileContent(packages);
+    expect(models).toBeDefined();
+    expect(models).toBe(
+      formatCode(`import { model, string } from "ronin/schema";
+
+export const User = model({
+  slug: "user",
+  fields: {
+    name: string({ required: true }),
+  },            
+});
+
+export const Post = model({
+  slug: "post",
+  fields: {
+    title: string(),
+  },
+});`),
+    );
+  });
+
+  test('model with index', async () => {
+    spyOn(modelModule, 'getModels').mockResolvedValue([
+      {
+        slug: 'user',
+        fields: [{ slug: 'name', type: 'string', required: true }],
+        indexes: {
+          indexSlug: {
+            fields: [{ slug: 'name' }],
+            unique: true,
+          },
+        },
+      },
+    ]);
+
+    const packages = await getLocalPackages();
+    const models = await getModelDefinitionsFileContent(packages);
+    expect(models).toBeDefined();
+    expect(models).toBe(
+      formatCode(`import { model, string } from "ronin/schema";
+
+export const User = model({
+  slug: "user",
+  fields: {
+    name: string({ required: true }),
+  },
+  indexes: { indexSlug: { fields: [{ slug: 'name' }], unique: true } },
+});`),
+    );
+  });
+});
+
+describe('command', () => {
+  const tempDir = path.join(tmpdir(), `ronin-test-${Date.now()}`);
+  const originalCwd = process.cwd();
+
+  spyOn(process, 'exit').mockImplementation(() => {
+    throw new Error('Process exit');
+  });
+
+  beforeAll(async () => {
+    const packageJson = JSON.parse(await fs.readFile('package.json', 'utf-8'));
+    // Create temp directory.
+    await fs.mkdir(tempDir, { recursive: true });
+    // Change to temp directory.
+    process.chdir(tempDir);
+    // Initialize project.
+    await $`bun init -y`;
+    // Install RONIN packages.
+    await $`bun add ronin@${packageJson.devDependencies.ronin || 'latest'}`;
+    // Create schema directory.
+    await fs.mkdir(path.join(tempDir, 'schema'));
+  });
+
+  afterAll(async () => {
+    // Change back to original directory.
+    process.chdir(originalCwd);
+    // Clean up temp directory.
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  afterEach(async () => {
+    // Clean up the schema directory.
+    await fs.rm(MODEL_IN_CODE_PATH, { force: true });
+  });
+
+  test('no models', async () => {
+    spyOn(modelModule, 'getModels').mockResolvedValue([]);
+
+    try {
+      await pull(undefined, undefined, true);
+    } catch (error) {
+      expect(error).toBeInstanceOf(Error);
+      // @ts-expect-error This is a mock.
+      expect(error.message).toBe('Process exit');
+    }
+  });
+
+  test('creates model file', async () => {
+    // Mock a valid model response.
+    spyOn(modelModule, 'getModels').mockResolvedValue([
+      {
+        slug: 'user',
+        fields: [
+          {
+            slug: 'name',
+            type: 'string',
+            required: true,
+          },
+        ],
+      },
+    ]);
+
+    await pull(undefined, undefined, true);
+
+    // Verify file was created in temp directory.
+    const fileExists = await fs.exists(MODEL_IN_CODE_PATH);
+
+    expect(fileExists).toBe(true);
+
+    // Verify file content.
+    const content = await fs.readFile(MODEL_IN_CODE_PATH, 'utf-8');
+    expect(content).toContain('export const User = model({');
+    expect(content).toContain('name: string({ required: true })');
+  });
+
+  test('overwrites model file', async () => {
+    // Create a model file.
+    await fs.writeFile(MODEL_IN_CODE_PATH, '// This is a test.');
+
+    // Mock confirm to return true.
+    spyOn(confirmModule, 'confirm').mockResolvedValue(true);
+
+    // Mock a valid model response.
+    spyOn(modelModule, 'getModels').mockResolvedValue([
+      {
+        slug: 'user',
+        fields: [
+          {
+            slug: 'name',
+            type: 'string',
+            required: true,
+          },
+        ],
+      },
+    ]);
+
+    await pull(undefined, undefined, true);
+
+    const fileExists = await fs.exists(MODEL_IN_CODE_PATH);
+
+    expect(fileExists).toBe(true);
+
+    // Verify file content
+    const content = await fs.readFile(MODEL_IN_CODE_PATH, 'utf-8');
+    expect(content).toContain('export const User = model({');
+    expect(content).toContain('name: string({ required: true })');
+  });
+
+  test('dont overwrite model file', async () => {
+    // Create a model file.
+    await fs.writeFile(MODEL_IN_CODE_PATH, '// This is a test.');
+
+    // Mock confirm to return true.
+    spyOn(confirmModule, 'confirm').mockResolvedValue(false);
+
+    // Mock a valid model response.
+    spyOn(modelModule, 'getModels').mockResolvedValue([
+      {
+        slug: 'user',
+        fields: [
+          {
+            slug: 'name',
+            type: 'string',
+            required: true,
+          },
+        ],
+      },
+    ]);
+
+    await pull(undefined, undefined, true);
+
+    const fileExists = await fs.exists(MODEL_IN_CODE_PATH);
+
+    expect(fileExists).toBe(true);
+
+    // Verify file content.
+    const content = await fs.readFile(MODEL_IN_CODE_PATH, 'utf-8');
+    expect(content).toBe('// This is a test.');
+  });
+
+  test('pulled model are up to date', async () => {
+    // Create a model file.
+    await fs.writeFile(
+      MODEL_IN_CODE_PATH,
+      `import { model } from "ronin/schema";
+
+export const User = model({
+  slug: "user",
+});
+`,
+    );
+
+    // Mock confirm to return true.
+    spyOn(confirmModule, 'confirm').mockResolvedValue(false);
+
+    // Mock a valid model response.
+    spyOn(modelModule, 'getModels').mockResolvedValue([
+      {
+        slug: 'user',
+        fields: [],
+      },
+    ]);
+
+    await pull(undefined, undefined, true);
+
+    const fileExists = await fs.exists(MODEL_IN_CODE_PATH);
+
+    expect(fileExists).toBe(true);
+
+    // Verify file content.
+    const content = await fs.readFile(MODEL_IN_CODE_PATH, 'utf-8');
+    expect(content).toBe(
+      'import { model } from "ronin/schema";\n\nexport const User = model({\n  slug: "user",\n});\n',
+    );
+  });
+});


### PR DESCRIPTION
This pull request introduces a new feature that allows users to execute the `ronin pull` command. This command fetches model definitions and integrates them into the model definition file, with the default file being `schema/index.ts`.