### PR TITLE
Fix missing model directory in `ronin pull`

### DIFF
--- a/src/commands/pull.ts
+++ b/src/commands/pull.ts
@@ -100,7 +100,7 @@ export const getModelDefinitionsFileContent = async (
   const importStatements = `import { model, ${primitives.join(',')} } from "ronin/schema";`;
 
   const modelDefinitions = models.map((model) => {
-    // We want to remove the ronin property from the model.
+    // We want to exclude the ronin property from the model.
     const { fields, indexes, ronin, ...rest } = model as ModelWithFieldsArray & {
       ronin: unknown;
     };

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1134,6 +1134,8 @@ describe('CLI', () => {
     test('pulled model are up to date', async () => {
       process.argv = ['bun', 'ronin', 'pull'];
 
+      spyOn(spaceModule, 'getOrSelectSpaceId').mockResolvedValue('test-space');
+
       await run({ version: '1.0.0' });
 
       expect(

--- a/tests/utils/pull.test.ts
+++ b/tests/utils/pull.test.ts
@@ -6,11 +6,13 @@ import pull, { getModelDefinitionsFileContent } from '@/src/commands/pull';
 import { formatCode } from '@/src/utils/format';
 import { MODEL_IN_CODE_PATH, getLocalPackages } from '@/src/utils/misc';
 import * as modelModule from '@/src/utils/model';
+import * as spaceModule from '@/src/utils/space';
 import * as confirmModule from '@inquirer/prompts';
 import { $ } from 'bun';
 
 describe('helper', () => {
   test('no models', async () => {
+    spyOn(spaceModule, 'getOrSelectSpaceId').mockResolvedValue('spaceId');
     spyOn(modelModule, 'getModels').mockResolvedValue([]);
 
     const packages = await getLocalPackages();
@@ -177,6 +179,7 @@ describe('command', () => {
   });
 
   test('creates model file', async () => {
+    spyOn(spaceModule, 'getOrSelectSpaceId').mockResolvedValue('spaceId');
     // Mock a valid model response.
     spyOn(modelModule, 'getModels').mockResolvedValue([
       {
@@ -207,6 +210,8 @@ describe('command', () => {
   test('overwrites model file', async () => {
     // Create a model file.
     await fs.writeFile(MODEL_IN_CODE_PATH, '// This is a test.');
+
+    spyOn(spaceModule, 'getOrSelectSpaceId').mockResolvedValue('spaceId');
 
     // Mock confirm to return true.
     spyOn(confirmModule, 'confirm').mockResolvedValue(true);
@@ -280,6 +285,8 @@ export const User = model({
 });
 `,
     );
+
+    spyOn(spaceModule, 'getOrSelectSpaceId').mockResolvedValue('spaceId');
 
     // Mock confirm to return true.
     spyOn(confirmModule, 'confirm').mockResolvedValue(false);


### PR DESCRIPTION
This pull request fixes the `ronin pull` command by checking for and creating the model definition directory if it doesn't exist, preventing crashes. Additionally, it ensures that the space ID is correctly passed and utilised during the pull process.