### PR TITLE
Correctly support nested fields

### DIFF
--- a/src/utils/field.ts
+++ b/src/utils/field.ts
@@ -107,13 +107,15 @@ export class CompareModels {
       required: false,
     }));
 
+    const tempModelSlug = `${RONIN_SCHEMA_TEMP_SUFFIX}${modelSlug}`;
+
     const queries = [
       // Set the default value for all existing records.
-      `set.RONIN_TEMP_${modelSlug}.to({${field.slug}: ${
+      `set${tempModelSlug.includes('.') ? `["${tempModelSlug}"]` : `.${tempModelSlug}`}.to({"${field.slug}": ${
         typeof defaultValue === 'string' ? `"${defaultValue}"` : defaultValue
       }})`,
       // Re-add the NOT NULL constraint after defaults are set.
-      `alter.model("RONIN_TEMP_${modelSlug}").alter.field("${field.slug}").to({required: true})`,
+      `alter.model("${tempModelSlug}").alter.field("${field.slug}").to({required: true})`,
     ];
 
     return {
@@ -468,9 +470,9 @@ export class CompareModels {
         diff.push(createFieldQuery(modelSlug, { ...fieldToAdd, required: false }));
         // Now set a placeholder value.
         diff.push(
-          `set.${modelSlug}.to({${fieldToAdd.slug}: ${
-            typeof defaultValue === 'boolean' ? defaultValue : `"${defaultValue}"`
-          }})`,
+          `set${modelSlug.includes('.') ? `["${modelSlug}"]` : `.${modelSlug}`}.to({"${
+            fieldToAdd.slug
+          }": ${typeof defaultValue === 'boolean' ? defaultValue : `"${defaultValue}"`}})`,
         );
         // Now add the NOT NULL constraint.
         diff.push(

--- a/src/utils/queries.ts
+++ b/src/utils/queries.ts
@@ -190,10 +190,13 @@ export const createTempColumnQuery = (
     }),
   );
 
+  const tempFieldSlug = `${RONIN_SCHEMA_TEMP_SUFFIX}${field.slug}`;
   // 2. Copy all data from the original field to the temporary field.
   // This preserves the data while we make the schema changes.
   queries.push(
-    `set.${modelSlug}.to.${RONIN_SCHEMA_TEMP_SUFFIX}${field.slug}(f => ${field.slug.includes('.') ? `f["${field.slug}"]` : `f.${field.slug}`})`,
+    `set${modelSlug.includes('.') ? `["${modelSlug}"]` : `.${modelSlug}`}.to${
+      field.slug.includes('.') ? `["${tempFieldSlug}"]` : `.${tempFieldSlug}`
+    }(f => ${field.slug.includes('.') ? `f["${field.slug}"]` : `f.${field.slug}`})`,
   );
 
   // 3. Remove the original field now that data is safely copied.
@@ -202,9 +205,7 @@ export const createTempColumnQuery = (
 
   // 4. Rename the temporary field to the original field name.
   // This completes the field modification while preserving the data.
-  queries.push(
-    renameFieldQuery(modelSlug, `${RONIN_SCHEMA_TEMP_SUFFIX}${field.slug}`, field.slug),
-  );
+  queries.push(renameFieldQuery(modelSlug, tempFieldSlug, field.slug));
 
   return queries;
 };

--- a/tests/utils/queries.test.ts
+++ b/tests/utils/queries.test.ts
@@ -206,7 +206,7 @@ describe('queries', () => {
     );
     expect(result).toEqual([
       'alter.model(\'user\').create.field({"slug":"RONIN_TEMP_profile.username","type":"string","name":"Username","unique":true,"required":true})',
-      'set.user.to.RONIN_TEMP_profile.username(f => f["profile.username"])',
+      'set.user.to["RONIN_TEMP_profile.username"](f => f["profile.username"])',
       'alter.model("user").drop.field("profile.username")',
       'alter.model("user").alter.field("RONIN_TEMP_profile.username").to({slug: "profile.username"})',
     ]);


### PR DESCRIPTION
In https://github.com/ronin-co/cli/pull/94 I added support for migrations for nested fields. However I didn't consider all queries that contain the model slug which could contain a `.`. 