### PR TITLE
Added missing peer dependency

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8,7 +8,6 @@
         "@dprint/typescript": "0.93.3",
         "@iarna/toml": "2.2.5",
         "@inquirer/prompts": "7.2.3",
-        "@ronin/engine": "0.1.23",
         "chalk-template": "1.1.0",
         "get-port": "7.1.0",
         "ini": "5.0.0",
@@ -28,6 +27,7 @@
       },
       "peerDependencies": {
         "@ronin/compiler": ">=0.18.0",
+        "@ronin/engine": ">=0.1.23",
         "@ronin/syntax": ">=0.2.40",
       },
     },

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "@dprint/typescript": "0.93.3",
     "@iarna/toml": "2.2.5",
     "@inquirer/prompts": "7.2.3",
-    "@ronin/engine": "0.1.23",
     "chalk-template": "1.1.0",
     "get-port": "7.1.0",
     "ini": "5.0.0",
@@ -52,6 +51,7 @@
   },
   "peerDependencies": {
     "@ronin/compiler": ">=0.18.0",
-    "@ronin/syntax": ">=0.2.40"
+    "@ronin/syntax": ">=0.2.40",
+    "@ronin/engine": ">=0.1.23"
   }
 }


### PR DESCRIPTION
This change was missing from https://github.com/ronin-co/cli/pull/98 and ensures that all peer dependencies are correctly defined.