### PR TITLE
Remove ineffective foreign key pragmas

### DIFF
--- a/src/commands/apply.ts
+++ b/src/commands/apply.ts
@@ -81,12 +81,6 @@ export default async (
       })),
     );
 
-    const turnOffPragma = { statement: 'PRAGMA foreign_keys = OFF', params: [] };
-    const turnOnPragma = { statement: 'PRAGMA foreign_keys = ON', params: [] };
-
-    statements.unshift(turnOffPragma);
-    statements.push(turnOnPragma);
-
     await applyMigrationStatements(
       appToken ?? sessionToken,
       flags,


### PR DESCRIPTION
Removed ineffective foreign key pragmas from migrations as they don't work within transactions.